### PR TITLE
Feat#13 register lesson/register student and lesson name footer

### DIFF
--- a/src/components/RegisterLessonPage/Footer.tsx
+++ b/src/components/RegisterLessonPage/Footer.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+export default function Footer() {
+
+    return (
+        <FooterWrapper>
+            <FooterButton> 정기수업 일정 등록하기 </FooterButton>
+        </FooterWrapper>
+    );
+}
+
+const FooterWrapper = styled.footer`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    position: fixed;
+    bottom: 0;
+    
+    width: 32rem;
+    height: 6.3rem;
+    padding: 0.8rem;
+    
+    background-color: ${({ theme }) => theme.colors.grey50};
+`
+
+const FooterButton = styled.button`
+    display: flex;
+    
+    ${({ theme }) => theme.fonts.body02};
+    color: ${({ theme }) => theme.colors.grey200};
+`

--- a/src/pages/RegisterLesson.tsx
+++ b/src/pages/RegisterLesson.tsx
@@ -1,3 +1,4 @@
+import Footer from '../components/RegisterLessonPage/Footer';
 import Header from '../components/RegisterLessonPage/Header';
 import LessonInput from '../components/RegisterLessonPage/LessonInput';
 
@@ -6,6 +7,7 @@ export default function RegisterLesson() {
   <>
     <Header />
     <LessonInput />
+    <Footer />
   </>
   );
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #13 

## 💙 작업 내용

- [x] 수업 등록 페이지 푸터 UI 구현

## ✅ PR Point

푸터 ui를 구현했습니다....! 

```JS
export default function Footer() {

    return (
        <FooterWrapper>
            <FooterButton> 정기수업 일정 등록하기 </FooterButton>
        </FooterWrapper>
    );
}
```

사이즈에 관계없이 맨 밑에 오도록 하기 위해서 position : fixed 속성을 이용했어용!

```JS
const FooterWrapper = styled.footer`
    display: flex;
    flex-direction: column;
    align-items: center;

    position: fixed;
    bottom: 0;
    
    width: 32rem;
    height: 6.3rem;
    padding: 0.8rem;
    
    background-color: ${({ theme }) => theme.colors.grey50};
`
```

## 😡 Trouble Shooting
없었습니다!

## 👀 스크린샷 / GIF / 링크
![image](https://github.com/Gwasuwon-shot/Tutice_Client/assets/116873401/10897d2e-a2d9-4dac-802b-b4ba0ef9fbbe)


