### PR TITLE
Feat#24 common/round button

### DIFF
--- a/src/components/common/RoundBottomButton.tsx
+++ b/src/components/common/RoundBottomButton.tsx
@@ -1,0 +1,26 @@
+import { styled } from "styled-components";
+
+interface RoundBottomButtonProps {
+  buttonMessage: string;
+}
+
+export default function RoundBottomButton(props: RoundBottomButtonProps) {
+  const { buttonMessage } = props;
+  return <RoundBottomButtonWrapper>{buttonMessage}</RoundBottomButtonWrapper>;
+}
+
+const RoundBottomButtonWrapper = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 29.2rem;
+  height: 5rem;
+
+  background-color: ${({ theme }) => theme.colors.green5};
+  color: ${({ theme }) => theme.colors.grey0};
+
+  ${({ theme }) => theme.fonts.title02};
+
+  border-radius: 0.8rem;
+`;

--- a/src/components/common/RoundBottomButton.tsx
+++ b/src/components/common/RoundBottomButton.tsx
@@ -23,4 +23,9 @@ const RoundBottomButtonWrapper = styled.button`
   ${({ theme }) => theme.fonts.title02};
 
   border-radius: 0.8rem;
+
+  &:active {
+    background-color: ${({ theme }) => theme.colors.green7};
+    color: ${({ theme }) => theme.colors.green4};
+  }
 `;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,4 +14,7 @@ export default defineConfig({
       },
     }),
   ],
+  optimizeDeps: {
+    exclude: ["js-big-decimal"],
+  },
 });


### PR DESCRIPTION
## 🔥 Related Issues

- close #24 

## 💙 작업 내용

- [x] ~ 모서리 둥근 하단 버튼 공통 컴포넌트로 빼기 

## ✅ PR Point

- 모서리가 둥근 하단 버튼을 공통 컴포넌트로 만들었어요. 버튼에 들어가는 텍스트를 props로 내려줍니다. 
```js
export default function RoundBottomButton(props: RoundBottomButtonProps) {
  const { buttonMessage } = props;
  return <RoundBottomButtonWrapper>{buttonMessage}</RoundBottomButtonWrapper>;
}
```

## 😡 Trouble Shooting
- 이 브랜치에 들어갈 내용은 원래 아니지만...! recoil-persist가 머지하고 나니 에러를 발생시켜서 `vite.config.js` 에 내용을 추가하였습니다~!
```js
  optimizeDeps: {
    exclude: ["js-big-decimal"],
  },
```

## 👀 스크린샷 / GIF / 링크
<img width="307" alt="KakaoTalk_Photo_2023-07-12-02-33-03" src="https://github.com/Gwasuwon-shot/Tutice_Client/assets/63237389/e1ba2a6f-627d-461e-b2bf-2130ad386a72">
