### PR TITLE
Feat#34 common/basic single modal

### DIFF
--- a/src/components/common/BasicDoubleModal.tsx
+++ b/src/components/common/BasicDoubleModal.tsx
@@ -1,0 +1,79 @@
+import { ReactNode } from "react";
+import useModal from "../../hooks/useModal";
+import styled from "styled-components";
+
+interface BasicDoubleModalProps {
+  children: ReactNode;
+  leftButtonName: string;
+  rightButtonName: string;
+  handleClickLeftButton: (e: React.MouseEvent<HTMLElement>) => void;
+  handleClickRightButton: (e: React.MouseEvent<HTMLElement>) => void;
+}
+
+export default function BasicDoubleModal(props: BasicDoubleModalProps) {
+  const { children, leftButtonName, rightButtonName, handleClickLeftButton, handleClickRightButton } = props;
+  const { modalRef, closeModal } = useModal();
+
+  return (
+    <ModalWrapper ref={modalRef}>
+      <Modal>
+        <ModalContents>{children}</ModalContents>
+        <Button type="button" onClick={handleClickLeftButton}>
+          {buttonName}
+        </Button>
+      </Modal>
+    </ModalWrapper>
+  );
+}
+
+const ModalWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  position: absolute;
+  z-index: 2;
+
+  width: 32rem;
+  height: 100vh;
+
+  background-color: rgb(33 37 41 / 60%);
+
+  cursor: pointer;
+`;
+
+const ModalContents = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  width: 100%;
+  height: 11.8rem;
+`;
+
+const Modal = styled.aside`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  width: 26.4rem;
+  height: 16.4rem;
+  border-radius: 8px;
+
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+const Button = styled.button`
+  width: 100%;
+  height: 4.6rem;
+  padding: 1.4rem 3.2rem 1.4rem 3.3rem;
+
+  border-radius: 0 0 8px 8px;
+
+  background-color: ${({ theme }) => theme.colors.green5};
+  color: ${({ theme }) => theme.colors.white};
+
+  ${({ theme }) => theme.fonts.title02};
+`;

--- a/src/components/common/BasicDoubleModal.tsx
+++ b/src/components/common/BasicDoubleModal.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
-import useModal from "../../hooks/useModal";
 import styled from "styled-components";
+import useModal from "../../hooks/useModal";
 
 interface BasicDoubleModalProps {
   children: ReactNode;
@@ -18,9 +18,14 @@ export default function BasicDoubleModal(props: BasicDoubleModalProps) {
     <ModalWrapper ref={modalRef}>
       <Modal>
         <ModalContents>{children}</ModalContents>
-        <Button type="button" onClick={handleClickLeftButton}>
-          {buttonName}
-        </Button>
+        <ButtonWrapper>
+          <Button type="button" onClick={handleClickLeftButton}>
+            {leftButtonName}
+          </Button>
+          <Button type="button" onClick={handleClickRightButton}>
+            {rightButtonName}
+          </Button>
+        </ButtonWrapper>
       </Modal>
     </ModalWrapper>
   );
@@ -77,3 +82,5 @@ const Button = styled.button`
 
   ${({ theme }) => theme.fonts.title02};
 `;
+
+const ButtonWrapper = styled.section``;

--- a/src/components/common/BasicDoubleModal.tsx
+++ b/src/components/common/BasicDoubleModal.tsx
@@ -19,10 +19,10 @@ export default function BasicDoubleModal(props: BasicDoubleModalProps) {
       <Modal>
         <ModalContents>{children}</ModalContents>
         <ButtonWrapper>
-          <Button type="button" onClick={handleClickLeftButton}>
+          <Button type="button" onClick={handleClickLeftButton} $isLeft={true}>
             {leftButtonName}
           </Button>
-          <Button type="button" onClick={handleClickRightButton}>
+          <Button type="button" onClick={handleClickRightButton} $isLeft={false}>
             {rightButtonName}
           </Button>
         </ButtonWrapper>
@@ -70,17 +70,21 @@ const Modal = styled.aside`
   background-color: ${({ theme }) => theme.colors.white};
 `;
 
-const Button = styled.button`
-  width: 100%;
-  height: 4.6rem;
-  padding: 1.4rem 3.2rem 1.4rem 3.3rem;
+const Button = styled.button<{ $isLeft: boolean }>`
+  width: 50%;
+  height: 100%;
 
-  border-radius: 0 0 8px 8px;
-
-  background-color: ${({ theme }) => theme.colors.green5};
-  color: ${({ theme }) => theme.colors.white};
+  background-color: ${({ theme, $isLeft }) => ($isLeft ? theme.colors.green1 : theme.colors.green5)};
+  color: ${({ theme, $isLeft }) => ($isLeft ? theme.colors.green5 : theme.colors.white)};
 
   ${({ theme }) => theme.fonts.title02};
 `;
 
-const ButtonWrapper = styled.section``;
+const ButtonWrapper = styled.section`
+  overflow: hidden;
+
+  width: 100%;
+  height: 4.6rem;
+
+  border-radius: 0 0 8px 8px;
+`;

--- a/src/components/common/BasicSingleModal.tsx
+++ b/src/components/common/BasicSingleModal.tsx
@@ -1,0 +1,35 @@
+import { ReactNode } from "react";
+import styled from "styled-components";
+import useModal from "../../hooks/useModal";
+
+interface BasicSingleModalProps {
+  children: ReactNode;
+  buttonName: string;
+  handleClickSingleButton: (e: React.MouseEvent<HTMLElement>) => void;
+}
+
+export default function BasicSingleModal(props: BasicSingleModalProps) {
+  const { children, buttonName, handleClickSingleButton } = props;
+  const { modalRef, closeModal } = useModal();
+
+  return (
+    <ModalWrapper ref={modalRef}>
+      <Modal>{children}</Modal>
+      <button onClick={handleClickSingleButton}>{buttonName}</button>
+    </ModalWrapper>
+  );
+}
+
+const ModalWrapper = styled.div`
+  position: absolute;
+  z-index: 2;
+
+  width: 32rem;
+  height: 100vh;
+
+  background-color: rgb(33 37 41 / 60%);
+
+  cursor: pointer;
+`;
+
+const Modal = styled.aside``;

--- a/src/components/common/BasicSingleModal.tsx
+++ b/src/components/common/BasicSingleModal.tsx
@@ -14,13 +14,21 @@ export default function BasicSingleModal(props: BasicSingleModalProps) {
 
   return (
     <ModalWrapper ref={modalRef}>
-      <Modal>{children}</Modal>
-      <button onClick={handleClickSingleButton}>{buttonName}</button>
+      <Modal>
+        <ModalContents>{children}</ModalContents>
+        <Button type="button" onClick={handleClickSingleButton}>
+          {buttonName}
+        </Button>
+      </Modal>
     </ModalWrapper>
   );
 }
 
 const ModalWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
   position: absolute;
   z-index: 2;
 
@@ -32,4 +40,38 @@ const ModalWrapper = styled.div`
   cursor: pointer;
 `;
 
-const Modal = styled.aside``;
+const ModalContents = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  width: 100%;
+  height: 11.8rem;
+`;
+
+const Modal = styled.aside`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  width: 26.4rem;
+  height: 16.4rem;
+  border-radius: 8px;
+
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+const Button = styled.button`
+  width: 100%;
+  height: 4.6rem;
+  padding: 1.4rem 3.2rem 1.4rem 3.3rem;
+
+  border-radius: 0 0 8px 8px;
+
+  background-color: ${({ theme }) => theme.colors.green5};
+  color: ${({ theme }) => theme.colors.white};
+
+  ${({ theme }) => theme.fonts.title02};
+`;

--- a/src/components/teacherHome/TeacherHome.tsx
+++ b/src/components/teacherHome/TeacherHome.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
 import { styled } from "styled-components";
 import { isModalOpen } from "../../atom/common/isModalOpen";
-import BasicSingleModal from "../common/BasicSingleModal";
+import BasicDoubleModal from "../common/BasicDoubleModal";
 import Header from "../common/Header";
 import TeacherFooter from "../common/TeacherFooter";
 import AlarmNUpcomingClass from "./AlarmNUpcomingClass";
@@ -15,17 +16,26 @@ export default function TeacherHome() {
 
   const [openModal, setOpenModal] = useRecoilState<boolean>(isModalOpen);
 
+  const navigate = useNavigate();
+
   function handleModalClose() {
     setOpenModal(false);
+  }
+
+  function handleMoveToSchedule() {
+    navigate("/schedule");
   }
 
   return (
     <>
       {openModal && (
-        <BasicSingleModal buttonName="확인" handleClickSingleButton={handleModalClose}>
-          <h1>출결 누락 알림</h1>
-          <p>어쩌구저쩌구</p>
-        </BasicSingleModal>
+        <BasicDoubleModal
+          leftButtonName="취소"
+          rightButtonName="확인"
+          handleClickLeftButton={handleModalClose}
+          handleClickRightButton={handleMoveToSchedule}>
+          <p>출석으로 체크하시겠어요?</p>
+        </BasicDoubleModal>
       )}
       <TeacherHomeWrapper>
         <Header />

--- a/src/components/teacherHome/TeacherHome.tsx
+++ b/src/components/teacherHome/TeacherHome.tsx
@@ -2,9 +2,9 @@ import { useState } from "react";
 import { useRecoilState } from "recoil";
 import { styled } from "styled-components";
 import { isModalOpen } from "../../atom/common/isModalOpen";
+import BasicSingleModal from "../common/BasicSingleModal";
 import Header from "../common/Header";
 import TeacherFooter from "../common/TeacherFooter";
-import ToastModal from "../common/ToastModal";
 import AlarmNUpcomingClass from "./AlarmNUpcomingClass";
 import NoClassHome from "./NoClassHome";
 import WelcomeNUpPreviewBanner from "./WelcomeNUpPreviewBanner";
@@ -15,12 +15,17 @@ export default function TeacherHome() {
 
   const [openModal, setOpenModal] = useRecoilState<boolean>(isModalOpen);
 
+  function handleModalClose() {
+    setOpenModal(false);
+  }
+
   return (
     <>
       {openModal && (
-        <ToastModal>
-          안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요{" "}
-        </ToastModal>
+        <BasicSingleModal buttonName="확인" handleClickSingleButton={handleModalClose}>
+          <h1>출결 누락 알림</h1>
+          <p>어쩌구저쩌구</p>
+        </BasicSingleModal>
       )}
       <TeacherHomeWrapper>
         <Header />


### PR DESCRIPTION
## 🔥 Related Issues

- close #34

## 💙 작업 내용

- [x] 싱글 버튼 모달 구현

## ✅ PR Point
> # common
- 토스트 모달 만들 때 썼던 커스텀 훅 그대로 사용함!

> # BasicSingleModal.tsx
```
interface BasicSingleModalProps {
  children: ReactNode;
  buttonName: string;
  handleClickSingleButton: (e: React.MouseEvent<HTMLElement>) => void;
}

export default function BasicSingleModal(props: BasicSingleModalProps) {
  const { children, buttonName, handleClickSingleButton } = props;
  const { modalRef, closeModal } = useModal();

  return (
    <ModalWrapper ref={modalRef}>
      <Modal>
        <ModalContents>{children}</ModalContents>
        <Button type="button" onClick={handleClickSingleButton}>
          {buttonName}
        </Button>
      </Modal>
    </ModalWrapper>
  );
}
```
(1) 모달 안의 내용물은 children으로, (2) 버튼 텍스트 (3) 버튼을 눌렀을 때 이루어지는 함수는 props로 내려받게 했습니다!

> # 사용방법
 ```
 const [openModal, setOpenModal] = useRecoilState<boolean>(isModalOpen);

  function handleModalClose() {
    setOpenModal(false);
  }

  return (
    <>
      {openModal && (
        <BasicSingleModal buttonName="확인" handleClickSingleButton={handleModalClose}>
          <h1>출결 누락 알림</h1>
          <p>어쩌구저쩌구</p>
        </BasicSingleModal>
      )}
```
지금 현재 코드로는, 확인을 눌렀을 때에도 모달이 닫히는 로직만 구현함~

## 👀 스크린샷 / GIF / 링크

https://github.com/Gwasuwon-shot/Tutice_Client/assets/76681519/9d4c9114-aada-4383-be3d-965b7d5b5766

