### PR TITLE
Refactor#87 home/refactor data flow

### DIFF
--- a/src/components/teacherHome/AlarmBanner.tsx
+++ b/src/components/teacherHome/AlarmBanner.tsx
@@ -1,13 +1,9 @@
 import styled from "styled-components";
 import { MissingAttendaceTeacherHomeIc, MissingMaintenanceTeacherHomeIc } from "../../assets";
+import useGetLatestScheduleByTeacher from "../../hooks/useGetLatestScheduleByTeacher";
 
-interface AlarmBannerProps {
-  isMissingAttendance: boolean;
-  isMissingMaintenance: boolean;
-}
-
-export default function AlarmBanner(props: AlarmBannerProps) {
-  const { isMissingAttendance, isMissingMaintenance } = props;
+export default function AlarmBanner() {
+  const { isMissingAttendance, isMissingMaintenance } = useGetLatestScheduleByTeacher();
 
   return (
     <>

--- a/src/components/teacherHome/AlarmNUpcomingClass.tsx
+++ b/src/components/teacherHome/AlarmNUpcomingClass.tsx
@@ -1,15 +1,15 @@
-import { YES_TODAY_CLASS_ING_CLASS_MAIN } from "../../core/teacherHome/teacherHome";
+import useGetTodayScheduleByTeacher from "../../hooks/useGetLatestScheduleByTeacher";
 import AlarmBanner from "./AlarmBanner";
 import UpcomingClassBoard from "./UpcomingClassBoard";
 
 export default function AlarmNUpcomingClass() {
   const { isMissingAttendance, isMissingMaintenance, latestScheduleDay, latestScheduleList } =
-    YES_TODAY_CLASS_ING_CLASS_MAIN.data;
+    useGetTodayScheduleByTeacher();
 
   return (
     <>
-      <AlarmBanner isMissingAttendance={isMissingAttendance} isMissingMaintenance={isMissingMaintenance} />
-      <UpcomingClassBoard latestScheduleDay={latestScheduleDay} latestScheduleList={latestScheduleList} />
+      <AlarmBanner />
+      <UpcomingClassBoard />
     </>
   );
 }

--- a/src/components/teacherHome/NoClassHome.tsx
+++ b/src/components/teacherHome/NoClassHome.tsx
@@ -1,19 +1,16 @@
 import { styled } from "styled-components";
 import { NoClassLogoTeacherHomeIc } from "../../assets";
-import useGetTodayScheduleByTeacher from "../../hooks/useGetTodayScheduleByTeacher";
 import RoundBottomButton from "../common/RoundBottomButton";
 import WelcomeTeacher from "./WelcomeTeacher";
 
 export default function NoClassHome() {
-  const { teacherName, isTodaySchedule, todaySchedule } = useGetTodayScheduleByTeacher();
-
   function handleMakeTreeCode() {
     // 나무 코드 생성 로직
   }
 
   return (
     <>
-      <WelcomeTeacher teacherName={teacherName} isTodaySchedule={isTodaySchedule} todaySchedule={todaySchedule} />
+      <WelcomeTeacher />
       <NoClassHomeWrapper>
         <NoClassLogoTeacherHomeIcon />
         <NoClassNotice> 아직 등록된 수업이 없어요!</NoClassNotice>
@@ -21,9 +18,9 @@ export default function NoClassHome() {
           <p> 나무 코드 생성을 통해 학생을 추가하고 </p>
           <p>링크를 학부모님에게 공유해보세요</p>
         </SubContext>
-        <ButtonWrapper onClick={handleMakeTreeCode}>
+        <div onClick={handleMakeTreeCode}>
           <RoundBottomButton buttonMessage="나무코드 생성하기" />
-        </ButtonWrapper>
+        </div>
       </NoClassHomeWrapper>
     </>
   );

--- a/src/components/teacherHome/NoClassHome.tsx
+++ b/src/components/teacherHome/NoClassHome.tsx
@@ -7,6 +7,10 @@ import WelcomeTeacher from "./WelcomeTeacher";
 export default function NoClassHome() {
   const { teacherName, isTodaySchedule, todaySchedule } = useGetTodayScheduleByTeacher();
 
+  function handleMakeTreeCode() {
+    // 나무 코드 생성 로직
+  }
+
   return (
     <>
       <WelcomeTeacher teacherName={teacherName} isTodaySchedule={isTodaySchedule} todaySchedule={todaySchedule} />
@@ -17,8 +21,9 @@ export default function NoClassHome() {
           <p> 나무 코드 생성을 통해 학생을 추가하고 </p>
           <p>링크를 학부모님에게 공유해보세요</p>
         </SubContext>
-        <
-        <RoundBottomButton buttonMessage="나무코드 생성하기"/>
+        <ButtonWrapper onClick={handleMakeTreeCode}>
+          <RoundBottomButton buttonMessage="나무코드 생성하기" />
+        </ButtonWrapper>
       </NoClassHomeWrapper>
     </>
   );

--- a/src/components/teacherHome/NoClassHome.tsx
+++ b/src/components/teacherHome/NoClassHome.tsx
@@ -1,10 +1,11 @@
 import { styled } from "styled-components";
 import { NoClassLogoTeacherHomeIc } from "../../assets";
-import { NO_REGISTERED_CLASS_BANNER } from "../../core/teacherHome/teacherHome";
+import useGetTodayScheduleByTeacher from "../../hooks/useGetTodayScheduleByTeacher";
+import RoundBottomButton from "../common/RoundBottomButton";
 import WelcomeTeacher from "./WelcomeTeacher";
 
 export default function NoClassHome() {
-  const { teacherName, isTodaySchedule, todaySchedule } = NO_REGISTERED_CLASS_BANNER.data;
+  const { teacherName, isTodaySchedule, todaySchedule } = useGetTodayScheduleByTeacher();
 
   return (
     <>
@@ -16,8 +17,8 @@ export default function NoClassHome() {
           <p> 나무 코드 생성을 통해 학생을 추가하고 </p>
           <p>링크를 학부모님에게 공유해보세요</p>
         </SubContext>
-        {/* 성경이가 만들 공통 컴포넌트 연결하기 */}
-        <Button type="button">나무코드 생성하기</Button>
+        <
+        <RoundBottomButton buttonMessage="나무코드 생성하기"/>
       </NoClassHomeWrapper>
     </>
   );
@@ -47,21 +48,4 @@ const SubContext = styled.div`
 
   text-align: center;
   ${({ theme }) => theme.fonts.body07};
-`;
-
-const Button = styled.button`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  width: 29.2rem;
-  height: 5rem;
-  padding: 0.8rem;
-
-  background-color: ${({ theme }) => theme.colors.green5};
-  color: ${({ theme }) => theme.colors.white};
-  gap: 0.8rem;
-  flex-shrink: 0;
-
-  border-radius: 8px;
 `;

--- a/src/components/teacherHome/UpcomingClassBoard.tsx
+++ b/src/components/teacherHome/UpcomingClassBoard.tsx
@@ -1,15 +1,10 @@
 import { useState } from "react";
 import styled from "styled-components";
-import { LatestScheduleDayType, UpcomingClassScheduleType } from "../../type/teacherHome/upcomingClassScheduleType";
+import useGetLatestScheduleByTeacher from "../../hooks/useGetLatestScheduleByTeacher";
 import UpcomingClass from "./UpcomingClass";
 
-interface UpcomingClassBoardProps {
-  latestScheduleDay: LatestScheduleDayType;
-  latestScheduleList: UpcomingClassScheduleType[];
-}
-
-export default function UpcomingClassBoard(props: UpcomingClassBoardProps) {
-  const { latestScheduleDay, latestScheduleList } = props;
+export default function UpcomingClassBoard() {
+  const { latestScheduleDay, latestScheduleList } = useGetLatestScheduleByTeacher();
   const { date, dayOfWeek } = latestScheduleDay;
   const [upcomingClassDate, setUpcomingClassDate] = useState(
     date.split("-")[0] + "년 " + date.split("-")[1] + "월 " + date.split("-")[2] + "일 ",

--- a/src/components/teacherHome/WelcomeNUpPreviewBanner.tsx
+++ b/src/components/teacherHome/WelcomeNUpPreviewBanner.tsx
@@ -1,16 +1,16 @@
 import { useState } from "react";
 import { useRecoilState } from "recoil";
 import { styled } from "styled-components";
-import { upcomingClassData } from "../../atom/attendanceCheck/upcomingClassData";
 import { isModalOpen } from "../../atom/common/isModalOpen";
+import useGetTodayScheduleByTeacher from "../../hooks/useGetTodayScheduleByTeacher";
 import AttendanceCheckModal from "../common/AttendanceCheckModal";
 import AttendanceDoubleCheckingModal from "../common/AttendanceDoubleCheckingModal";
 import PreviewBanner from "./PreviewBanner";
 import WelcomeTeacher from "./WelcomeTeacher";
 
 export default function WelcomeNUpcomingBanner() {
-  const [classData, setclassData] = useRecoilState(upcomingClassData);
-  const { teacherName, isTodaySchedule, todaySchedule } = classData;
+  const { teacherName, isTodaySchedule, todaySchedule } = useGetTodayScheduleByTeacher();
+
   const [openModal, setOpenModal] = useRecoilState<boolean>(isModalOpen);
   const [isCheckingModalOpen, setIsCheckingModalOpen] = useState(false);
 

--- a/src/components/teacherHome/WelcomeTeacher.tsx
+++ b/src/components/teacherHome/WelcomeTeacher.tsx
@@ -1,11 +1,9 @@
-import { useRecoilState } from "recoil";
 import { styled } from "styled-components";
-import { upcomingClassData } from "../../atom/attendanceCheck/upcomingClassData";
 import { WELCOME_TEACHER_COMMENTS } from "../../core/teacherHome/welcomeTeacherComments";
+import useGetTodayScheduleByTeacher from "../../hooks/useGetTodayScheduleByTeacher";
 
 export default function WelcomeTeacher() {
-  const [classData, setclassData] = useRecoilState(upcomingClassData);
-  const { teacherName, isTodaySchedule, todaySchedule } = classData;
+  const { teacherName, isTodaySchedule, todaySchedule } = useGetTodayScheduleByTeacher();
 
   function checkTodayClassEnd() {
     return isTodaySchedule && todaySchedule === null;

--- a/src/hooks/useGetLatestScheduleByTeacher.ts
+++ b/src/hooks/useGetLatestScheduleByTeacher.ts
@@ -1,6 +1,6 @@
 import { YES_TODAY_CLASS_BEFORE_CLASS_MAIN } from "../core/teacherHome/teacherHome";
 
-export default function useGetTodayScheduleByTeacher() {
+export default function useGetLatestScheduleByTeacher() {
   // 선생님 : 메인페이지 뷰 (홈)- 오늘의 수업/곧 다가오는 수업
   //   api 패칭
   const { isMissingAttendance, isMissingMaintenance, isTodaySchedule, latestScheduleDay, latestScheduleList } =

--- a/src/hooks/useGetLatestScheduleByTeacher.ts
+++ b/src/hooks/useGetLatestScheduleByTeacher.ts
@@ -1,0 +1,10 @@
+import { YES_TODAY_CLASS_BEFORE_CLASS_MAIN } from "../core/teacherHome/teacherHome";
+
+export default function useGetTodayScheduleByTeacher() {
+  // 선생님 : 메인페이지 뷰 (홈)- 오늘의 수업/곧 다가오는 수업
+  //   api 패칭
+  const { isMissingAttendance, isMissingMaintenance, isTodaySchedule, latestScheduleDay, latestScheduleList } =
+    YES_TODAY_CLASS_BEFORE_CLASS_MAIN?.data;
+
+  return { isMissingAttendance, isMissingMaintenance, isTodaySchedule, latestScheduleDay, latestScheduleList };
+}

--- a/src/hooks/useGetTodayScheduleByTeacher.ts
+++ b/src/hooks/useGetTodayScheduleByTeacher.ts
@@ -1,0 +1,9 @@
+import { YES_TODAY_CLASS_BEFORE_CLASS_BANNER } from "../core/teacherHome/teacherHome";
+
+export default function useGetTodayScheduleByTeacher() {
+  // 선생님 : 메인페이지 뷰 (홈)- 배너(가장 가까운 수업)
+  //   api 패칭
+  const { teacherName, isTodaySchedule, todaySchedule } = YES_TODAY_CLASS_BEFORE_CLASS_BANNER?.data;
+
+  return { teacherName, isTodaySchedule, todaySchedule };
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import ParentsHome from "../components/parentsHome/ParentsHome";
 import TeacherHome from "../components/teacherHome/TeacherHome";
 
 export default function Home() {
-  const [isTeacherHome, setIsTeacherHome] = useState(false);
+  const [isTeacherHome, setIsTeacherHome] = useState(true);
   return (
     <>
       {/* 선생님인 경우 TeacherHome, 학부모인 경우 ParentHome 컴포넌트 띄워주기*/}


### PR DESCRIPTION
## 🔥 Related Issues

- close #87

## 💙 작업 내용

- [x] 리코일로 저장하던 서버 데이터 커스텀 훅으로 분리

## ✅ PR Point

- 서버에서 받아온 데이터를 그대로 사용하기 위해서 리액트 쿼리를 사용하는데, 그 데이터를 또다시 리코일에 그대로 저장하는 로직이 어색하다고 생각했어요. 대신, 리액트 쿼리의 캐시를 이용해서 staleTime을 설정하고 리액트 쿼리로 데이터 패칭해오는 과정을 커스텀 훅으로 분리하면 훨씬 깔끔하게 api 통신을 할 수 있을 것이라고 생각했습니다 

→ 데이터 패칭을 생각해보았을 때, props나 atom보다는 
리액트쿼리로 api통신하는 과정을 커스텀 훅으로 만드는 방법이 가장 좋아보여요! 
→ 이유1 한 페이지에 보여지는 데이터가 하나의 api로 오는 경우가 많은데 컴포넌트를 잘게 쪼개게 되면, props는 drilling이 너무 심해짐. 
→ 이유2 마찬가지로, 한 페이지에 보여지는 데이터가 하나의 api로 오는 경우가 많은데, 그 페이지에서만 관리될 데이터를 전역변수로 선언하는 것은 어색하다고 생각. 전역적으로 쓰이는 게 아니라, 쪼개진 컴포넌트에서 공통적으로 사용될 데이터이기 때문!

