### PR TITLE
Feat#134 parents calendar/api

### DIFF
--- a/src/api/getScheduleByUser.ts
+++ b/src/api/getScheduleByUser.ts
@@ -1,0 +1,13 @@
+import axios from "axios";
+import React from "react";
+
+export async function getScheduleByUser(date: string) {
+  const data = await axios.get(`${import.meta.env.VITE_APP_BASE_URL}/api/schedule/?month=${date}`, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${import.meta.env.VITE_APP_PARENTS_TOKEN}`,
+    },
+  });
+  console.log(data);
+  return data;
+}

--- a/src/api/getScheduleByUser.ts
+++ b/src/api/getScheduleByUser.ts
@@ -2,10 +2,11 @@ import axios from "axios";
 import React from "react";
 
 export async function getScheduleByUser(date: string) {
+  console.log(import.meta.env.VITE_APP_TEACHER_TOKEN);
   const data = await axios.get(`${import.meta.env.VITE_APP_BASE_URL}/api/schedule/?month=${date}`, {
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${import.meta.env.VITE_APP_PARENTS_TOKEN}`,
+      Authorization: `Bearer ${import.meta.env.VITE_APP_TEACHER_TOCKEN}`,
     },
   });
   console.log(data);

--- a/src/api/getScheduleByUser.ts
+++ b/src/api/getScheduleByUser.ts
@@ -2,13 +2,12 @@ import axios from "axios";
 import React from "react";
 
 export async function getScheduleByUser(date: string) {
-  console.log(import.meta.env.VITE_APP_TEACHER_TOKEN);
   const data = await axios.get(`${import.meta.env.VITE_APP_BASE_URL}/api/schedule/?month=${date}`, {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${import.meta.env.VITE_APP_TEACHER_TOCKEN}`,
     },
   });
-  console.log(data);
-  return data;
+  console.log(data.data.data);
+  return data?.data?.data?.scheduleList;
 }

--- a/src/components/Calendar/Parents/ParentModal.tsx
+++ b/src/components/Calendar/Parents/ParentModal.tsx
@@ -8,18 +8,21 @@ import StudentColorBox from "../../common/StudentColorBox";
 import ToastModal from "../../common/ToastModal";
 import useGetScheduleChild from "../../../hooks/useGetScheduleChild";
 import { modalType } from "../../../type/calendar/modalType";
+import useGetScheduleByUser from "../../../hooks/useGetScheduleByUser";
 
 export default function ParentModal(props: modalType) {
-  const { selectedDate, setOpenModal } = props;
+  const { selectedDate, setOpenModal, formattedMonth } = props;
   const { scheduleList } = useGetScheduleChild();
 
+  const { isUserSchedule } = useGetScheduleByUser(formattedMonth);
+  console.log(isUserSchedule);
   return (
     <>
       <ToastModal>
         <ModalContentWrapper>
           <ModalDate>{format(selectedDate as Date, "M월 d일 EEEE", { locale: ko })}</ModalDate>
-          {scheduleList
-            .find((item) => isSameDay(new Date(item.date), selectedDate as Date))
+          {isUserSchedule
+            ?.find((item) => isSameDay(new Date(item.date), selectedDate as Date))
             ?.dailyScheduleList.map((item) => {
               const { schedule } = item;
               const { idx, studentName, subject, startTime, endTime } = schedule;

--- a/src/components/Calendar/Parents/ParentModal.tsx
+++ b/src/components/Calendar/Parents/ParentModal.tsx
@@ -12,10 +12,8 @@ import useGetScheduleByUser from "../../../hooks/useGetScheduleByUser";
 
 export default function ParentModal(props: modalType) {
   const { selectedDate, setOpenModal, formattedMonth } = props;
-  const { scheduleList } = useGetScheduleChild();
-
   const { isUserSchedule } = useGetScheduleByUser(formattedMonth);
-  console.log(isUserSchedule);
+
   return (
     <>
       <ToastModal>

--- a/src/components/Calendar/Parents/ParentModal.tsx
+++ b/src/components/Calendar/Parents/ParentModal.tsx
@@ -10,7 +10,14 @@ import useGetScheduleChild from "../../../hooks/useGetScheduleChild";
 import { modalType } from "../../../type/calendar/modalType";
 import useGetScheduleByUser from "../../../hooks/useGetScheduleByUser";
 
-export default function ParentModal(props: modalType) {
+ interface modalTypes {
+  selectedDate: Date;
+  setOpenModal: (open: boolean) => void;
+  formattedMonth: string;
+}
+
+
+export default function ParentModal(props: modalTypes) {
   const { selectedDate, setOpenModal, formattedMonth } = props;
   const { isUserSchedule } = useGetScheduleByUser(formattedMonth);
 

--- a/src/components/Calendar/Parents/ParentsDays.tsx
+++ b/src/components/Calendar/Parents/ParentsDays.tsx
@@ -20,11 +20,9 @@ export default function ParentsDays(props: DaysProp) {
   const endDate: Date = endOfWeek(monthEnd);
   const [openModal, setOpenModal] = useRecoilState<boolean>(isModalOpen);
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
-  const { scheduleList } = useGetScheduleChild();
   const formattedMonth = `${currentMonth.getFullYear()}-${String(currentMonth.getMonth() + 1).padStart(2, "0")}`;
-
+  
   const { isUserSchedule } = useGetScheduleByUser(formattedMonth);
-  console.log(isUserSchedule);
 
   const rows: React.ReactNode[] = [];
   let days: React.ReactNode[] = [];
@@ -63,7 +61,7 @@ export default function ParentsDays(props: DaysProp) {
         {rows}
         {openModal && selectedDate && (
           <ModalWrapper>
-            <ParentModal selectedDate={selectedDate} setOpenModal={setOpenModal} />
+            <ParentModal selectedDate={selectedDate} setOpenModal={setOpenModal} formattedMonth={formattedMonth} />
           </ModalWrapper>
         )}
       </DaysWrapper>

--- a/src/components/Calendar/Parents/ParentsDays.tsx
+++ b/src/components/Calendar/Parents/ParentsDays.tsx
@@ -6,6 +6,7 @@ import { format, endOfMonth, endOfWeek, startOfMonth, startOfWeek, addDays, isSa
 import ParentModal from "./ParentModal";
 import useGetScheduleChild from "../../../hooks/useGetScheduleChild";
 import ParentDayItem from "./ParentDayItem";
+import useGetScheduleByUser from "../../../hooks/useGetScheduleByUser";
 
 interface DaysProp {
   currentMonth: Date;
@@ -20,6 +21,9 @@ export default function ParentsDays(props: DaysProp) {
   const [openModal, setOpenModal] = useRecoilState<boolean>(isModalOpen);
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const { scheduleList } = useGetScheduleChild();
+  const formattedMonth = `${currentMonth.getFullYear()}-${String(currentMonth.getMonth() + 1).padStart(2, "0")}`;
+
+  const { isUserSchedule } = useGetScheduleByUser(formattedMonth);
 
   const rows: React.ReactNode[] = [];
   let days: React.ReactNode[] = [];
@@ -27,7 +31,7 @@ export default function ParentsDays(props: DaysProp) {
 
   while (day <= endDate) {
     for (let i = 0; i < 7; i++) {
-      const myChildLessons = scheduleList.find((item) => isSameDay(new Date(item.date), day));
+      const myChildLessons = isUserSchedule.find((item) => isSameDay(new Date(item.date), day));
       days.push(
         <ParentDayItem
           setOpenModal={setOpenModal}

--- a/src/components/Calendar/Parents/ParentsDays.tsx
+++ b/src/components/Calendar/Parents/ParentsDays.tsx
@@ -24,6 +24,7 @@ export default function ParentsDays(props: DaysProp) {
   const formattedMonth = `${currentMonth.getFullYear()}-${String(currentMonth.getMonth() + 1).padStart(2, "0")}`;
 
   const { isUserSchedule } = useGetScheduleByUser(formattedMonth);
+  console.log(isUserSchedule);
 
   const rows: React.ReactNode[] = [];
   let days: React.ReactNode[] = [];
@@ -31,7 +32,7 @@ export default function ParentsDays(props: DaysProp) {
 
   while (day <= endDate) {
     for (let i = 0; i < 7; i++) {
-      const myChildLessons = isUserSchedule.find((item) => isSameDay(new Date(item.date), day));
+      const myChildLessons = isUserSchedule?.find((item) => isSameDay(new Date(item.date), day));
       days.push(
         <ParentDayItem
           setOpenModal={setOpenModal}

--- a/src/hooks/useGetScheduleByUser.ts
+++ b/src/hooks/useGetScheduleByUser.ts
@@ -19,7 +19,7 @@ interface scheduleListType {
 export default function useGetScheduleByUser(date: string): { isUserSchedule: scheduleListType[] } {
   const [isUserSchedule, setIsUserSchedule] = useState<scheduleListType[]>([]);
 
-  const { data } = useQuery(["getScheduleByUser"], () => getScheduleByUser(date), {
+  const { data } = useQuery(["getScheduleByUser", date], () => getScheduleByUser(date), {
     onSuccess: (response) => {
       // setIsUserSchedule(response.data.scheduleList);
       console.log(response);

--- a/src/hooks/useGetScheduleByUser.ts
+++ b/src/hooks/useGetScheduleByUser.ts
@@ -17,18 +17,13 @@ interface scheduleListType {
 [];
 
 export default function useGetScheduleByUser(date: string): { isUserSchedule: scheduleListType[] } {
-  const [isUserSchedule, setIsUserSchedule] = useState<scheduleListType[]>([]);
-
-  const { data } = useQuery(["getScheduleByUser", date], () => getScheduleByUser(date), {
-    onSuccess: (response) => {
-      // setIsUserSchedule(response.data.scheduleList);
-      console.log(response);
-    },
+  const { data: isUserSchedule } = useQuery(["getScheduleByUser", date], () => getScheduleByUser(date), {
     onError: (error) => {
       console.log(error);
     },
     staleTime: 300000,
   });
+  console.log(isUserSchedule);
 
   return { isUserSchedule };
 }

--- a/src/hooks/useGetScheduleByUser.ts
+++ b/src/hooks/useGetScheduleByUser.ts
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { useQuery } from "react-query";
+import { getScheduleByUser } from "../api/getScheduleByUser";
+import { scheduleType } from "../type/scheduleType";
+
+interface dailyScheduleListType {
+  lessonIdx: number;
+  schedule: scheduleType;
+}
+[];
+
+interface scheduleListType {
+  date: string;
+  dayOfWeek: string;
+  dailyScheduleList: dailyScheduleListType[];
+}
+[];
+
+export default function useGetScheduleByUser(date: string): { isUserSchedule: scheduleListType[] } {
+  const [isUserSchedule, setIsUserSchedule] = useState<scheduleListType[]>([]);
+
+  const { data } = useQuery(["getScheduleByUser"], () => getScheduleByUser(date), {
+    onSuccess: (response) => {
+      // setIsUserSchedule(response.data.scheduleList);
+      console.log(response);
+    },
+    onError: (error) => {
+      console.log(error);
+    },
+    staleTime: 300000,
+  });
+
+  return { isUserSchedule };
+}

--- a/src/pages/ParentCalendar.tsx
+++ b/src/pages/ParentCalendar.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
-import { subMonths, addMonths } from "date-fns";
+import { subMonths, addMonths, setYear } from "date-fns";
 import YearandMonth from "../components/Calendar/YearandMonth";
 import Dayofweek from "../components/Calendar/Dayofweek";
 import ParentsDays from "../components/Calendar/Parents/ParentsDays";
@@ -8,6 +8,7 @@ import ParentsDays from "../components/Calendar/Parents/ParentsDays";
 //수정없는 부모님 캘린더
 export default function ParentCalenda() {
   const [currentMonth, setCurrentMonth] = useState<Date>(new Date());
+  const [YearMonth, setYearMonth] = useState<string>("");
 
   function handleToPrevMonth() {
     setCurrentMonth(subMonths(currentMonth, 1));

--- a/src/type/calendar/modalType.ts
+++ b/src/type/calendar/modalType.ts
@@ -3,5 +3,4 @@ import React from "react";
 export interface modalType {
   selectedDate: Date;
   setOpenModal: (open: boolean) => void;
-  formattedMonth: string;
 }

--- a/src/type/calendar/modalType.ts
+++ b/src/type/calendar/modalType.ts
@@ -2,6 +2,6 @@ import React from "react";
 
 export interface modalType {
   selectedDate: Date;
-  formattedMonth: string;
   setOpenModal: (open: boolean) => void;
+  formattedMonth: string;
 }

--- a/src/type/calendar/modalType.ts
+++ b/src/type/calendar/modalType.ts
@@ -2,5 +2,6 @@ import React from "react";
 
 export interface modalType {
   selectedDate: Date;
+  formattedMonth: string;
   setOpenModal: (open: boolean) => void;
 }

--- a/src/type/scheduleType.ts
+++ b/src/type/scheduleType.ts
@@ -1,3 +1,7 @@
 export interface scheduleType {
-    
+  idx: number;
+  studentName: string;
+  subject: string;
+  startTime: string;
+  endTime: string;
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #134

## 💙 작업 내용

- [x] ~ 부모 캘린더 api get
- [x] ~ 부모 캘린더 모달 api get

## ✅ PR Point

- reactquery는 데이터를 가공하지 않고 받아온 애를 날 것으로 이용하기 위한 거를 배워따!!! (by 지슈슈 ❤️ )
- 그렇기 때문에 그냥 data를 받아쓰는 애는 `state`를 쓰는 것보다 그냥 냅두는 게 나은 것도 배워부림!!!! 
- 그래서 여기에선 받아온 뒤 action이 없기 때문에 onSuccess를 쓰지 않았다! (이게 optional이라는 걸 배움!)
- 먼가 재밌다,,희휘

~~~~~~
export default function useGetScheduleByUser(date: string): { isUserSchedule: scheduleListType[] } {
  const { data: isUserSchedule } = useQuery(["getScheduleByUser", date], () => getScheduleByUser(date), {
    onError: (error) => {
      console.log(error);
    },
    staleTime: 300000,
  });
  console.log(isUserSchedule);

  return { isUserSchedule };
}

~~~~~~~

## 😡 Trouble Shooting
- 자꾸 401에러가 떠서,,,, 어제부터 계속 멘붕이었는데,,,,, 이유는 오타,,,,,,오타 조심하세요ㅠㅠ

## 👀 스크린샷 / GIF / 링크

## 📚 Reference

- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)
