### PR TITLE
Feat#176 home/teacher home api

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="shortcut icon" href="/tutice.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <link rel="manifest" href="js13kpwa.webmanifest" />
+    <link rel="/manifest" href="js13kpwa.webmanifest" />
     <link
       rel="stylesheet"
       as="style"

--- a/src/api/getLatestScheduleByTeacher.ts
+++ b/src/api/getLatestScheduleByTeacher.ts
@@ -1,12 +1,12 @@
 import axios from "axios";
 
-export async function getTodayScheduleByTeacher() {
-  const data = await axios.get(`${import.meta.env.VITE_APP_BASE_URL}/api/schedule/today/teacher`, {
+export async function getLatestScheduleByTeacher() {
+  const data = await axios.get(`${import.meta.env.VITE_APP_BASE_URL}/api/schedule/latest`, {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${import.meta.env.VITE_APP_TEACHER_TOCKEN}`,
     },
   });
-
+  console.log(data.data.data);
   return data.data.data;
 }

--- a/src/api/getLatestScheduleByTeacher.ts
+++ b/src/api/getLatestScheduleByTeacher.ts
@@ -7,6 +7,6 @@ export async function getLatestScheduleByTeacher() {
       Authorization: `Bearer ${import.meta.env.VITE_APP_TEACHER_TOCKEN}`,
     },
   });
-  console.log(data.data.data);
+
   return data.data.data;
 }

--- a/src/api/getLessonByTeacher.ts
+++ b/src/api/getLessonByTeacher.ts
@@ -7,6 +7,6 @@ export async function getLessonByTeacher() {
       Authorization: `Bearer ${import.meta.env.VITE_APP_TEACHER_TOCKEN}`,
     },
   });
-  console.log(data?.data?.data?.lessonList);
+
   return data?.data?.data?.lessonList;
 }

--- a/src/api/getLessonByUser.ts
+++ b/src/api/getLessonByUser.ts
@@ -8,7 +8,5 @@ export async function getLessonByUser() {
     },
   });
 
-  console.log(data);
-
   return data.data.data.isLesson;
 }

--- a/src/api/getTodayScheduleByTeacher.ts
+++ b/src/api/getTodayScheduleByTeacher.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+
+export async function getTodayScheduleByTeacher() {
+  const data = await axios.get(`${import.meta.env.VITE_APP_BASE_URL}/api/schedule/today/teacher`, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${import.meta.env.VITE_APP_TEACHER_TOCKEN}`,
+    },
+  });
+
+  console.log(data);
+
+  return data.data.data;
+}

--- a/src/api/getTodayScheduleByTeacher.ts
+++ b/src/api/getTodayScheduleByTeacher.ts
@@ -8,7 +8,7 @@ export async function getTodayScheduleByTeacher() {
     },
   });
 
-  console.log(data);
+  console.log(data.data.data);
 
   return data.data.data;
 }

--- a/src/atom/registerPayment/registerPayment.ts
+++ b/src/atom/registerPayment/registerPayment.ts
@@ -1,11 +1,11 @@
-import { atom } from 'recoil';
+import { atom } from "recoil";
 
 export const openPaymentPicker = atom<boolean>({
-    key: 'openPaymentPicker',
-    default: false,
-})
+  key: "openPaymentPicker",
+  default: false,
+});
 
 export const paymentDateState = atom({
-    key: 'dateState',
-    default: {year : new Date().getFullYear(), month : new Date().getMonth()+1, date: new Date().getDate()}
+  key: "paymentDateState",
+  default: { year: new Date().getFullYear(), month: new Date().getMonth() + 1, date: new Date().getDate() },
 });

--- a/src/components/common/AttendanceCheckModal.tsx
+++ b/src/components/common/AttendanceCheckModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
 import { attendanceLesson } from "../../atom/attendanceCheck/attendanceLesson";
@@ -19,6 +20,10 @@ export default function AttendanceCheckModal(props: AttendanceCheckModalProp) {
   const [attendanceData, setAttendanceData] = useRecoilState(attendanceStatus);
   const [selectedLesson, setSelectedLesson] = useRecoilState(attendanceLesson);
   const { lessonIdx, studentName, count, subject, scheduleIdx } = selectedLesson;
+
+  useEffect(() => {
+    setAttendanceData({ ...attendanceData, status: "" });
+  }, []);
 
   function handleCancelAttendanceCheck() {
     setOpenModal(false);

--- a/src/components/common/SendAlarmCheckModal.tsx
+++ b/src/components/common/SendAlarmCheckModal.tsx
@@ -31,6 +31,7 @@ export default function SendAlarmCheckModal(props: SendAlarmCheckModalProps) {
   }
 
   const queryClient = useQueryClient();
+
   const { data: sendAlarm } = useQuery(
     ["requestAttendanceNotification"],
     () => requestAttendanceNotification(scheduleIdx),

--- a/src/components/manageLesson/AttendanceInforms.tsx
+++ b/src/components/manageLesson/AttendanceInforms.tsx
@@ -5,7 +5,6 @@ import styled from "styled-components";
 import { attendanceLesson } from "../../atom/attendanceCheck/attendanceLesson";
 import { isModalOpen } from "../../atom/common/isModalOpen";
 import useGetLessonScheduleByTeacher from "../../hooks/useGetLessonScheduleByTeacher";
-import useModal from "../../hooks/useModal";
 import { ScheduleListType } from "../../type/manageLesson/scheduleListType";
 import AttendanceCheckModal from "../common/AttendanceCheckModal";
 import AttendanceDoubleCheckingModal from "../common/AttendanceDoubleCheckingModal";
@@ -17,7 +16,6 @@ export default function AttendanceInforms() {
   const { lessonIdx, count, nowCount, percent, studentName, subject, scheduleList } = useGetLessonScheduleByTeacher(
     Number(manageLessonId),
   );
-  const { modalRef, closeModal, unShowModal, showModal } = useModal();
   const [isCheckingModalOpen, setIsCheckingModalOpen] = useState(false);
   const [selectedLesson, setSelectedLesson] = useRecoilState(attendanceLesson);
   const [openModal, setOpenModal] = useRecoilState<boolean>(isModalOpen);

--- a/src/components/manageLesson/AttendanceInforms.tsx
+++ b/src/components/manageLesson/AttendanceInforms.tsx
@@ -29,6 +29,10 @@ export default function AttendanceInforms() {
     setIsCancelImpossibleModalOpen(false);
   }
 
+  function checkScheduleListExist() {
+    return scheduleList?.length != 0;
+  }
+
   return (
     <>
       {openModal && selectedLesson && (
@@ -49,21 +53,25 @@ export default function AttendanceInforms() {
       )}
 
       <GreyBox />
-      <ScheduleWrapper>
-        {scheduleList?.map(({ idx, date, status, startTime, endTime }: ScheduleListType, index: number) => (
-          <AttendanceInform
-            key={idx}
-            date={date}
-            status={status}
-            startTime={startTime}
-            endTime={endTime}
-            count={Math.abs(index - scheduleList?.length)}
-            lessonIdx={lessonIdx}
-            scheduleIdx={idx}
-            setIsCancelImpossibleModalOpen={setIsCancelImpossibleModalOpen}
-          />
-        ))}
-      </ScheduleWrapper>
+      {checkScheduleListExist() ? (
+        <ScheduleWrapper>
+          {scheduleList?.map(({ idx, date, status, startTime, endTime }: ScheduleListType, index: number) => (
+            <AttendanceInform
+              key={idx}
+              date={date}
+              status={status}
+              startTime={startTime}
+              endTime={endTime}
+              count={Math.abs(index - scheduleList?.length)}
+              lessonIdx={lessonIdx}
+              scheduleIdx={idx}
+              setIsCancelImpossibleModalOpen={setIsCancelImpossibleModalOpen}
+            />
+          ))}
+        </ScheduleWrapper>
+      ) : (
+        <p>수업이 없습니다</p>
+      )}
     </>
   );
 }

--- a/src/components/teacherHome/AlarmBanner.tsx
+++ b/src/components/teacherHome/AlarmBanner.tsx
@@ -1,14 +1,20 @@
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { MissingAttendaceTeacherHomeIc, MissingMaintenanceTeacherHomeIc } from "../../assets";
 import useGetLatestScheduleByTeacher from "../../hooks/useGetLatestScheduleByTeacher";
 
 export default function AlarmBanner() {
   const { isMissingAttendance, isMissingMaintenance } = useGetLatestScheduleByTeacher();
+  const navigate = useNavigate();
+
+  function handleMoveToMissingAttendaceCheck() {
+    navigate("/no-attendance-check");
+  }
 
   return (
     <>
       {isMissingMaintenance && <MissingMaintenanceTeacherHomeIcon />}
-      {isMissingAttendance && <MissingAttendaceTeacherHomeIcon />}
+      {isMissingAttendance && <MissingAttendaceTeacherHomeIcon onClick={handleMoveToMissingAttendaceCheck} />}
     </>
   );
 }

--- a/src/components/teacherHome/AlarmNUpcomingClass.tsx
+++ b/src/components/teacherHome/AlarmNUpcomingClass.tsx
@@ -1,11 +1,7 @@
-import useGetTodayScheduleByTeacher from "../../hooks/useGetLatestScheduleByTeacher";
 import AlarmBanner from "./AlarmBanner";
 import UpcomingClassBoard from "./UpcomingClassBoard";
 
 export default function AlarmNUpcomingClass() {
-  const { isMissingAttendance, isMissingMaintenance, latestScheduleDay, latestScheduleList } =
-    useGetTodayScheduleByTeacher();
-
   return (
     <>
       <AlarmBanner />

--- a/src/components/teacherHome/PreviewBanner.tsx
+++ b/src/components/teacherHome/PreviewBanner.tsx
@@ -1,12 +1,10 @@
-import { useRecoilState } from "recoil";
-import { upcomingClassData } from "../../atom/attendanceCheck/upcomingClassData";
 import { NO_CLASS_BANNER_TITLE } from "../../core/teacherHome/noClassBannerTitle";
+import useGetTodayScheduleByTeacher from "../../hooks/useGetTodayScheduleByTeacher";
 import ClassPreviewBanner from "./banner/ClassPreviewBanner";
 import NoclassBanner from "./banner/NoclassBanner";
 
 export default function Banner() {
-  const [classData, setclassData] = useRecoilState(upcomingClassData);
-  const { teacherName, isTodaySchedule, todaySchedule } = classData;
+  const { teacherName, isTodaySchedule, todaySchedule } = useGetTodayScheduleByTeacher();
 
   function checkClassEnd() {
     return todaySchedule === null;
@@ -23,7 +21,7 @@ export default function Banner() {
           {checkClassEnd() ? (
             <NoclassBanner bannerTitle={NO_CLASS_BANNER_TITLE.endTodayClass} />
           ) : (
-            <ClassPreviewBanner todaySchedule={todaySchedule} />
+            <ClassPreviewBanner />
           )}
         </>
       ) : (

--- a/src/components/teacherHome/UpcomingClass.tsx
+++ b/src/components/teacherHome/UpcomingClass.tsx
@@ -20,35 +20,42 @@ export default function UpcomingClass(props: UpcomingClassProps) {
 
   return (
     <UpcomingClassWrapper onClick={() => handleMoveToManageLessonDetail(idx)}>
-      <StudentColorBox backgroundColor={STUDENT_COLOR[idx % 11]} />
-      <ClassTimeWrapper>
-        {startTime} ~ {endTime}
-      </ClassTimeWrapper>
-      <StudentName>{studentName}</StudentName>
-      <SubjectLabel subject={subject} backgroundColor={STUDENT_COLOR[idx % 11]} color="#5B6166" />
+      <UpcomingClassBox>
+        <StudentColorBox backgroundColor={STUDENT_COLOR[idx % 11]} />
+        <ClassTimeWrapper>
+          {startTime} ~ {endTime}
+        </ClassTimeWrapper>
+        <StudentName>{studentName}</StudentName>
+        <SubjectLabel subject={subject} backgroundColor={STUDENT_COLOR[idx % 11]} color="#5B6166" />
+      </UpcomingClassBox>
       <RightArrowTeacherHomeIcon />
     </UpcomingClassWrapper>
   );
 }
 
-const UpcomingClassWrapper = styled.article`
+const UpcomingClassBox = styled.div`
   display: flex;
   justify-content: flex-start;
+  align-items: center;
+`;
+
+const UpcomingClassWrapper = styled.article`
+  display: flex;
+  justify-content: space-between;
   align-items: center;
 
   margin-top: 1.4rem;
 `;
 
 const ClassTimeWrapper = styled.p`
-  width: 7.5rem;
-  margin-left: 1.5rem;
+  width: 9rem;
+  padding-left: 1.4rem;
 
   color: ${({ theme }) => theme.colors.grey600};
   ${({ theme }) => theme.fonts.body05};
 `;
 
 const StudentName = styled.p`
-  width: 3.7rem;
   margin: 0 0.6rem 0 1.5rem;
 
   color: ${({ theme }) => theme.colors.grey900};
@@ -56,7 +63,6 @@ const StudentName = styled.p`
 `;
 
 const RightArrowTeacherHomeIcon = styled(RightArrowTeacherHomeIc)`
-  margin-left: 6rem;
   width: 2rem;
   height: 2rem;
   cursor: pointer;

--- a/src/components/teacherHome/UpcomingClassBoard.tsx
+++ b/src/components/teacherHome/UpcomingClassBoard.tsx
@@ -1,25 +1,23 @@
-import { useState } from "react";
 import styled from "styled-components";
 import useGetLatestScheduleByTeacher from "../../hooks/useGetLatestScheduleByTeacher";
-import UpcomingClass from "./UpcomingClass";
 
 export default function UpcomingClassBoard() {
   const { latestScheduleDay, latestScheduleList } = useGetLatestScheduleByTeacher();
-  const { date, dayOfWeek } = latestScheduleDay;
-  const [upcomingClassDate, setUpcomingClassDate] = useState(
-    date.split("-")[0] + "년 " + date.split("-")[1] + "월 " + date.split("-")[2] + "일 ",
-  );
+  // const { date, dayOfWeek } = latestScheduleDay;
+  // const [upcomingClassDate, setUpcomingClassDate] = useState(
+  //   date.split("-")[0] + "년 " + date.split("-")[1] + "월 " + date.split("-")[2] + "일 ",
+  // );
 
   return (
     <UpcomingClassBoardWrapper>
-      <UpcomingClassDate>
+      {/* <UpcomingClassDate>
         {upcomingClassDate}({dayOfWeek}) 수업
         <UpcomingClassWrapper>
           {latestScheduleList.map(({ lesson, schedule }, idx) => (
             <UpcomingClass key={idx} lesson={lesson} schedule={schedule} />
           ))}
         </UpcomingClassWrapper>
-      </UpcomingClassDate>
+      </UpcomingClassDate> */}
     </UpcomingClassBoardWrapper>
   );
 }

--- a/src/components/teacherHome/UpcomingClassBoard.tsx
+++ b/src/components/teacherHome/UpcomingClassBoard.tsx
@@ -1,23 +1,30 @@
+import { useState } from "react";
 import styled from "styled-components";
 import useGetLatestScheduleByTeacher from "../../hooks/useGetLatestScheduleByTeacher";
+import UpcomingClass from "./UpcomingClass";
 
 export default function UpcomingClassBoard() {
   const { latestScheduleDay, latestScheduleList } = useGetLatestScheduleByTeacher();
-  // const { date, dayOfWeek } = latestScheduleDay;
-  // const [upcomingClassDate, setUpcomingClassDate] = useState(
-  //   date.split("-")[0] + "년 " + date.split("-")[1] + "월 " + date.split("-")[2] + "일 ",
-  // );
+  const { date, dayOfWeek } = latestScheduleDay;
+  const [upcomingClassDate, setUpcomingClassDate] = useState(
+    new Date(date).getFullYear() +
+      "년 " +
+      Number(new Date(date).getMonth() + 1) +
+      "월 " +
+      new Date(date).getDate() +
+      "일 ",
+  );
 
   return (
     <UpcomingClassBoardWrapper>
-      {/* <UpcomingClassDate>
+      <UpcomingClassDate>
         {upcomingClassDate}({dayOfWeek}) 수업
         <UpcomingClassWrapper>
-          {latestScheduleList.map(({ lesson, schedule }, idx) => (
+          {latestScheduleList.map(({ lesson, schedule }, idx: number) => (
             <UpcomingClass key={idx} lesson={lesson} schedule={schedule} />
           ))}
         </UpcomingClassWrapper>
-      </UpcomingClassDate> */}
+      </UpcomingClassDate>
     </UpcomingClassBoardWrapper>
   );
 }

--- a/src/components/teacherHome/UpcomingClassBoard.tsx
+++ b/src/components/teacherHome/UpcomingClassBoard.tsx
@@ -1,28 +1,31 @@
-import { useState } from "react";
 import styled from "styled-components";
 import useGetLatestScheduleByTeacher from "../../hooks/useGetLatestScheduleByTeacher";
+import { UpcomingClassScheduleType } from "../../type/teacherHome/upcomingClassScheduleType";
 import UpcomingClass from "./UpcomingClass";
 
 export default function UpcomingClassBoard() {
   const { latestScheduleDay, latestScheduleList } = useGetLatestScheduleByTeacher();
-  const { date, dayOfWeek } = latestScheduleDay;
-  const [upcomingClassDate, setUpcomingClassDate] = useState(
-    new Date(date).getFullYear() +
+
+  function checkUpcomingClassData() {
+    return (
+      new Date(latestScheduleDay?.date).getFullYear() +
       "년 " +
-      Number(new Date(date).getMonth() + 1) +
+      Number(new Date(latestScheduleDay?.date).getMonth() + 1) +
       "월 " +
-      new Date(date).getDate() +
-      "일 ",
-  );
+      new Date(latestScheduleDay?.date).getDate() +
+      "일 "
+    );
+  }
 
   return (
     <UpcomingClassBoardWrapper>
       <UpcomingClassDate>
-        {upcomingClassDate}({dayOfWeek}) 수업
+        {checkUpcomingClassData()}({latestScheduleDay?.dayOfWeek}) 수업
         <UpcomingClassWrapper>
-          {latestScheduleList.map(({ lesson, schedule }, idx: number) => (
-            <UpcomingClass key={idx} lesson={lesson} schedule={schedule} />
-          ))}
+          {latestScheduleList &&
+            latestScheduleList?.map(({ lesson, schedule }: UpcomingClassScheduleType, idx: number) => (
+              <UpcomingClass key={idx} lesson={lesson} schedule={schedule} />
+            ))}
         </UpcomingClassWrapper>
       </UpcomingClassDate>
     </UpcomingClassBoardWrapper>

--- a/src/components/teacherHome/banner/ClassPreviewBanner.tsx
+++ b/src/components/teacherHome/banner/ClassPreviewBanner.tsx
@@ -1,19 +1,20 @@
 import { styled } from "styled-components";
 import { UpcomingClassLogoTeacherHomeIc } from "../../../assets";
 import { CLASS_PREVIEW_BANNER_COMMENTS } from "../../../core/teacherHome/classPreviewBannerComments";
-import { PreviewBannerScheduleType } from "../../../type/teacherHome/previewBannerScheduleType";
+import useGetTodayScheduleByTeacher from "../../../hooks/useGetTodayScheduleByTeacher";
 import AttendanceCheckButton from "../../common/AttendanceCheckButton";
 import SubjectLabel from "../../common/SubjectLabel";
 
-interface ClassPreviewBannerProps {
-  todaySchedule: PreviewBannerScheduleType;
-}
+// interface ClassPreviewBannerProps {
+//   todaySchedule: PreviewBannerScheduleType;
+// }
 
-export default function ClassPreviewBanner(props: ClassPreviewBannerProps) {
-  const { todaySchedule } = props;
+export default function ClassPreviewBanner() {
+  const { todaySchedule } = useGetTodayScheduleByTeacher();
   const { lesson, timeStatus, schedule } = todaySchedule;
   const { studentName, subject } = lesson;
   const { count } = schedule;
+  console.log(todaySchedule);
 
   function showClassPreviewComment(timeStatus: number) {
     switch (timeStatus) {
@@ -36,7 +37,8 @@ export default function ClassPreviewBanner(props: ClassPreviewBannerProps) {
     <ClassPreviewBannerWrapper>
       <article>
         <StudentNameWrapper>
-          <b>{studentName}</b> 학생
+          <StudentName>{studentName}</StudentName>
+          <Student>학생</Student>
           <SubjectLabel subject={subject} backgroundColor="#B0E0D6" color="#00997D" />
         </StudentNameWrapper>
         <ClassStatusWrapper>
@@ -70,9 +72,17 @@ const StudentNameWrapper = styled.h1`
   justify-content: space-between;
   align-items: center;
 
-  width: 10.8rem;
+  margin-right: 1rem;
 
   ${({ theme }) => theme.fonts.title02};
+`;
+
+const StudentName = styled.p`
+  ${({ theme }) => theme.fonts.title02};
+`;
+
+const Student = styled.p`
+  ${({ theme }) => theme.fonts.title03};
 `;
 
 const ClassStatusWrapper = styled.p`

--- a/src/components/teacherHome/banner/ClassPreviewBanner.tsx
+++ b/src/components/teacherHome/banner/ClassPreviewBanner.tsx
@@ -64,7 +64,6 @@ const ClassPreviewBannerWrapper = styled.section`
 
 const StudentNameWrapper = styled.h1`
   display: flex;
-  justify-content: space-between;
   align-items: center;
 
   margin-right: 1rem;
@@ -77,6 +76,7 @@ const StudentName = styled.p`
 `;
 
 const Student = styled.p`
+  margin: 0 0.5rem;
   ${({ theme }) => theme.fonts.title03};
 `;
 

--- a/src/components/teacherHome/banner/ClassPreviewBanner.tsx
+++ b/src/components/teacherHome/banner/ClassPreviewBanner.tsx
@@ -5,16 +5,11 @@ import useGetTodayScheduleByTeacher from "../../../hooks/useGetTodayScheduleByTe
 import AttendanceCheckButton from "../../common/AttendanceCheckButton";
 import SubjectLabel from "../../common/SubjectLabel";
 
-// interface ClassPreviewBannerProps {
-//   todaySchedule: PreviewBannerScheduleType;
-// }
-
 export default function ClassPreviewBanner() {
   const { todaySchedule } = useGetTodayScheduleByTeacher();
   const { lesson, timeStatus, schedule } = todaySchedule;
   const { studentName, subject } = lesson;
   const { expectedCount } = schedule;
-  console.log(todaySchedule);
 
   function showClassPreviewComment(timeStatus: number) {
     switch (timeStatus) {

--- a/src/components/teacherHome/banner/ClassPreviewBanner.tsx
+++ b/src/components/teacherHome/banner/ClassPreviewBanner.tsx
@@ -13,7 +13,7 @@ export default function ClassPreviewBanner() {
   const { todaySchedule } = useGetTodayScheduleByTeacher();
   const { lesson, timeStatus, schedule } = todaySchedule;
   const { studentName, subject } = lesson;
-  const { count } = schedule;
+  const { expectedCount } = schedule;
   console.log(todaySchedule);
 
   function showClassPreviewComment(timeStatus: number) {
@@ -42,7 +42,7 @@ export default function ClassPreviewBanner() {
           <SubjectLabel subject={subject} backgroundColor="#B0E0D6" color="#00997D" />
         </StudentNameWrapper>
         <ClassStatusWrapper>
-          <ClassCountMentWrapper>{count} 회차 수업이</ClassCountMentWrapper>
+          <ClassCountMentWrapper>{expectedCount}회차 수업이</ClassCountMentWrapper>
           {showClassPreviewComment(timeStatus)}
         </ClassStatusWrapper>
       </article>

--- a/src/hooks/useGetAllLessons.ts
+++ b/src/hooks/useGetAllLessons.ts
@@ -7,7 +7,7 @@ export default function useGetAllLessons() {
     onError: (err) => {
       console.log(err);
     },
-    staleTime: 10000,
+    staleTime: 3000,
   });
 
   return { lessonList };

--- a/src/hooks/useGetAllLessons.ts
+++ b/src/hooks/useGetAllLessons.ts
@@ -7,7 +7,7 @@ export default function useGetAllLessons() {
     onError: (err) => {
       console.log(err);
     },
-    staleTime: 300000,
+    staleTime: 10000,
   });
 
   return { lessonList };

--- a/src/hooks/useGetLatestScheduleByTeacher.ts
+++ b/src/hooks/useGetLatestScheduleByTeacher.ts
@@ -8,7 +8,7 @@ export default function useGetLatestScheduleByTeacher() {
     onError: (error) => {
       console.log(error);
     },
-    staleTime: 10000,
+    staleTime: 3000,
   });
 
   const isMissingAttendance = latestScheduleByTeacher?.isMissingAttendance;

--- a/src/hooks/useGetLatestScheduleByTeacher.ts
+++ b/src/hooks/useGetLatestScheduleByTeacher.ts
@@ -8,7 +8,7 @@ export default function useGetLatestScheduleByTeacher() {
     onError: (error) => {
       console.log(error);
     },
-    staleTime: 30000,
+    staleTime: 10000,
   });
 
   const isMissingAttendance = latestScheduleByTeacher?.isMissingAttendance;

--- a/src/hooks/useGetLatestScheduleByTeacher.ts
+++ b/src/hooks/useGetLatestScheduleByTeacher.ts
@@ -1,10 +1,21 @@
-import { YES_TODAY_CLASS_BEFORE_CLASS_MAIN } from "../core/teacherHome/teacherHome";
+import { useQuery } from "react-query";
+import { getLatestScheduleByTeacher } from "../api/getLatestScheduleByTeacher";
 
 export default function useGetLatestScheduleByTeacher() {
   // 선생님 : 메인페이지 뷰 (홈)- 오늘의 수업/곧 다가오는 수업
   //   api 패칭
-  const { isMissingAttendance, isMissingMaintenance, isTodaySchedule, latestScheduleDay, latestScheduleList } =
-    YES_TODAY_CLASS_BEFORE_CLASS_MAIN?.data;
+  const { data: latestScheduleByTeacher } = useQuery(["latestScheduleByTeacher"], getLatestScheduleByTeacher, {
+    onError: (error) => {
+      console.log(error);
+    },
+    staleTime: 30000,
+  });
+
+  const isMissingAttendance = latestScheduleByTeacher?.isMissingAttendance;
+  const isMissingMaintenance = latestScheduleByTeacher?.isMissingMaintenance;
+  const isTodaySchedule = latestScheduleByTeacher?.isTodaySchedule;
+  const latestScheduleDay = latestScheduleByTeacher?.latestScheduleDay;
+  const latestScheduleList = latestScheduleByTeacher?.latestScheduleList;
 
   return { isMissingAttendance, isMissingMaintenance, isTodaySchedule, latestScheduleDay, latestScheduleList };
 }

--- a/src/hooks/useGetLessonByUser.ts
+++ b/src/hooks/useGetLessonByUser.ts
@@ -3,7 +3,7 @@ import { getLessonByUser } from "../api/getLessonByUser";
 
 export default function useGetLessonByUser() {
   const { data: isLessonExist } = useQuery(["getLessonByUser"], getLessonByUser, {
-    staleTime: 300000,
+    staleTime: 10000,
   });
 
   return { isLessonExist };

--- a/src/hooks/useGetLessonByUser.ts
+++ b/src/hooks/useGetLessonByUser.ts
@@ -3,7 +3,7 @@ import { getLessonByUser } from "../api/getLessonByUser";
 
 export default function useGetLessonByUser() {
   const { data: isLessonExist } = useQuery(["getLessonByUser"], getLessonByUser, {
-    staleTime: 10000,
+    staleTime: 3000,
   });
 
   return { isLessonExist };

--- a/src/hooks/useGetLessonScheduleByTeacher.ts
+++ b/src/hooks/useGetLessonScheduleByTeacher.ts
@@ -9,7 +9,7 @@ export default function useGetLessonScheduleByTeacher(manageLessonId: number) {
       onError: (err) => {
         console.log(err);
       },
-      staleTime: 3000,
+      staleTime: 10000,
     },
   );
 

--- a/src/hooks/useGetLessonScheduleByTeacher.ts
+++ b/src/hooks/useGetLessonScheduleByTeacher.ts
@@ -9,7 +9,7 @@ export default function useGetLessonScheduleByTeacher(manageLessonId: number) {
       onError: (err) => {
         console.log(err);
       },
-      staleTime: 10000,
+      staleTime: 3000,
     },
   );
 

--- a/src/hooks/useGetMissingAttendanceSchedule.ts
+++ b/src/hooks/useGetMissingAttendanceSchedule.ts
@@ -3,7 +3,7 @@ import { getMissingAttendanceSchedule } from "../api/getMissingAttendanceSchedul
 
 export default function useGetMissingAttendanceSchedule() {
   const { data: missingAttendanceSchedule } = useQuery(["getMissingAttendanceSchedule"], getMissingAttendanceSchedule, {
-    staleTime: 300000,
+    staleTime: 10000,
   });
 
   return { missingAttendanceSchedule };

--- a/src/hooks/useGetMissingAttendanceSchedule.ts
+++ b/src/hooks/useGetMissingAttendanceSchedule.ts
@@ -3,7 +3,7 @@ import { getMissingAttendanceSchedule } from "../api/getMissingAttendanceSchedul
 
 export default function useGetMissingAttendanceSchedule() {
   const { data: missingAttendanceSchedule } = useQuery(["getMissingAttendanceSchedule"], getMissingAttendanceSchedule, {
-    staleTime: 10000,
+    staleTime: 3000,
   });
 
   return { missingAttendanceSchedule };

--- a/src/hooks/useGetScheduleByUser.ts
+++ b/src/hooks/useGetScheduleByUser.ts
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useQuery } from "react-query";
 import { getScheduleByUser } from "../api/getScheduleByUser";
 import { scheduleType } from "../type/scheduleType";
@@ -21,7 +20,7 @@ export default function useGetScheduleByUser(date: string): { isUserSchedule: sc
     onError: (error) => {
       console.log(error);
     },
-    staleTime: 300000,
+    staleTime: 10000,
   });
 
   return { isUserSchedule };

--- a/src/hooks/useGetScheduleByUser.ts
+++ b/src/hooks/useGetScheduleByUser.ts
@@ -20,7 +20,7 @@ export default function useGetScheduleByUser(date: string): { isUserSchedule: sc
     onError: (error) => {
       console.log(error);
     },
-    staleTime: 10000,
+    staleTime: 3000,
   });
 
   return { isUserSchedule };

--- a/src/hooks/useGetTodayScheduleByTeacher.ts
+++ b/src/hooks/useGetTodayScheduleByTeacher.ts
@@ -8,7 +8,7 @@ export default function useGetTodayScheduleByTeacher() {
     onError: (error) => {
       console.log(error);
     },
-    staleTime: 30000,
+    staleTime: 10000,
   });
 
   const teacherName = todayScheduleByTeacher?.teacherName;

--- a/src/hooks/useGetTodayScheduleByTeacher.ts
+++ b/src/hooks/useGetTodayScheduleByTeacher.ts
@@ -1,9 +1,19 @@
-import { YES_TODAY_CLASS_BEFORE_CLASS_BANNER } from "../core/teacherHome/teacherHome";
+import { useQuery } from "react-query";
+import { getTodayScheduleByTeacher } from "../api/getTodayScheduleByTeacher";
 
 export default function useGetTodayScheduleByTeacher() {
   // 선생님 : 메인페이지 뷰 (홈)- 배너(가장 가까운 수업)
   //   api 패칭
-  const { teacherName, isTodaySchedule, todaySchedule } = YES_TODAY_CLASS_BEFORE_CLASS_BANNER?.data;
+  const { data: todayScheduleByTeacher } = useQuery(["todayScheduleByTeacher"], getTodayScheduleByTeacher, {
+    onSuccess: () => {},
+    onError: (error) => {
+      console.log(error);
+    },
+  });
+
+  const teacherName = todayScheduleByTeacher?.teacherName;
+  const isTodaySchedule = todayScheduleByTeacher?.isTodaySchedule;
+  const todaySchedule = todayScheduleByTeacher?.todaySchedule;
 
   return { teacherName, isTodaySchedule, todaySchedule };
 }

--- a/src/hooks/useGetTodayScheduleByTeacher.ts
+++ b/src/hooks/useGetTodayScheduleByTeacher.ts
@@ -8,7 +8,7 @@ export default function useGetTodayScheduleByTeacher() {
     onError: (error) => {
       console.log(error);
     },
-    staleTime: 10000,
+    staleTime: 3000,
   });
 
   const teacherName = todayScheduleByTeacher?.teacherName;

--- a/src/hooks/useGetTodayScheduleByTeacher.ts
+++ b/src/hooks/useGetTodayScheduleByTeacher.ts
@@ -5,10 +5,10 @@ export default function useGetTodayScheduleByTeacher() {
   // 선생님 : 메인페이지 뷰 (홈)- 배너(가장 가까운 수업)
   //   api 패칭
   const { data: todayScheduleByTeacher } = useQuery(["todayScheduleByTeacher"], getTodayScheduleByTeacher, {
-    onSuccess: () => {},
     onError: (error) => {
       console.log(error);
     },
+    staleTime: 30000,
   });
 
   const teacherName = todayScheduleByTeacher?.teacherName;


### PR DESCRIPTION
## 🔥 Related Issues

- close #176

## 💙 작업 내용

- [x] 선생님 홈 API 연결

## ✅ PR Point
> # useGetTodayScheduleByTeacher
```
export default function useGetTodayScheduleByTeacher() {
  // 선생님 : 메인페이지 뷰 (홈)- 배너(가장 가까운 수업)
  //   api 패칭
  const { data: todayScheduleByTeacher } = useQuery(["todayScheduleByTeacher"], getTodayScheduleByTeacher, {
    onError: (error) => {
      console.log(error);
    },
    staleTime: 3000,
  });

  const teacherName = todayScheduleByTeacher?.teacherName;
  const isTodaySchedule = todayScheduleByTeacher?.isTodaySchedule;
  const todaySchedule = todayScheduleByTeacher?.todaySchedule;

  return { teacherName, isTodaySchedule, todaySchedule };
}
```
이전 데이터 패칭과 마찬가지로, 구조분해할당을 이용하지 않고, 옵셔널체이닝을 이용해서 데이터를 나누었어요.


## 👀 스크린샷 / GIF / 링크

https://github.com/Gwasuwon-shot/Tutice_Client/assets/76681519/cf31c37d-3fb0-4961-abb5-0239c32e54b0

