### PR TITLE
Fix#323 sign up/term2 qa

### DIFF
--- a/src/api/postCheckEmail.ts
+++ b/src/api/postCheckEmail.ts
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+export async function postCheckEmail(email: string) {
+  const data = await axios.post(`${import.meta.env.VITE_APP_BASE_URL}/api/auth/email/duplication`, { email: email });
+  return data;
+}

--- a/src/components/signup/AgreeChecking.tsx
+++ b/src/components/signup/AgreeChecking.tsx
@@ -17,7 +17,7 @@ type AgreeCheckingProp = {
   isConfirmed: boolean;
 };
 
-interface ResponseDataType {
+export interface ResponseDataType {
   message: string;
   code: number;
 }

--- a/src/components/signup/EmailCheckButton.tsx
+++ b/src/components/signup/EmailCheckButton.tsx
@@ -1,0 +1,36 @@
+import { styled } from "styled-components";
+
+interface CheckButtonProps {
+  text: string;
+  emailTyped: boolean;
+  onClick: () => void;
+}
+
+export default function CheckButton(props: CheckButtonProps) {
+  const { text, emailTyped, onClick } = props;
+  return (
+    <CheckButtonWrapper type="button" onClick={onClick} $emailTyped={emailTyped}>
+      <h1>{text}</h1>
+    </CheckButtonWrapper>
+  );
+}
+
+const CheckButtonWrapper = styled.button<{ $emailTyped: boolean }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 5.8rem;
+  height: 3rem;
+
+  border: 1px solid ${({ $emailTyped, theme }) => ($emailTyped ? theme.colors.green4 : theme.colors.grey70)};
+  background-color: ${({ $emailTyped, theme }) => ($emailTyped ? theme.colors.green5 : theme.colors.grey70)};
+  color: ${({ $emailTyped, theme }) => ($emailTyped ? theme.colors.grey0 : theme.colors.grey300)};
+  border-radius: 1rem;
+  ${({ theme }) => theme.fonts.body03};
+
+  &:active {
+    border: 1px solid ${({ theme }) => theme.colors.green6};
+    background-color: ${({ theme }) => theme.colors.green10};
+  }
+`;

--- a/src/components/signup/EmailDuplicatedModal.tsx
+++ b/src/components/signup/EmailDuplicatedModal.tsx
@@ -3,13 +3,14 @@ import BasicSingleModal from "../common/BasicSingleModal";
 
 interface EmailDuplicatedModalProps {
   handleCloseModal(): void;
+  modalMessage: string;
 }
 
 export default function EmailDuplicatedModal(props: EmailDuplicatedModalProps) {
-  const { handleCloseModal } = props;
+  const { handleCloseModal, modalMessage } = props;
   return (
     <BasicSingleModal buttonName="확인" handleClickSingleButton={handleCloseModal}>
-      <EmailIsDuplicated>이미 사용 중인 이메일 입니다.</EmailIsDuplicated>
+      <EmailIsDuplicated>{modalMessage}</EmailIsDuplicated>
     </BasicSingleModal>
   );
 }

--- a/src/components/signup/EmailDuplicatedModal.tsx
+++ b/src/components/signup/EmailDuplicatedModal.tsx
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+import BasicSingleModal from "../common/BasicSingleModal";
+
+interface EmailDuplicatedModalProps {
+  handleCloseModal(): void;
+}
+
+export default function EmailDuplicatedModal(props: EmailDuplicatedModalProps) {
+  const { handleCloseModal } = props;
+  return (
+    <BasicSingleModal buttonName="확인" handleClickSingleButton={handleCloseModal}>
+      <EmailIsDuplicated>이미 사용 중인 이메일 입니다.</EmailIsDuplicated>
+    </BasicSingleModal>
+  );
+}
+const EmailIsDuplicated = styled.h1`
+  display: flex;
+  justify-content: center;
+  text-align: center;
+
+  ${({ theme }) => theme.fonts.body02};
+`;

--- a/src/components/signup/NameEmail.tsx
+++ b/src/components/signup/NameEmail.tsx
@@ -15,6 +15,10 @@ import SignupTitleLayout from "./SignupTitleLayout";
 import TextLabelLayout from "./TextLabelLayout";
 import useSignupFormState from "../../hooks/useSignupFormState";
 import EmailCheckButton from "./EmailCheckButton";
+import { useMutation } from "react-query";
+import { isAxiosError } from "axios";
+import { ResponseDataType } from "./AgreeChecking";
+import { postCheckEmail } from "../../api/postCheckEmail";
 
 export default function NameEmail() {
   const [newUser, setNewUser] = useRecoilState(newUserData);
@@ -36,6 +40,21 @@ export default function NameEmail() {
     emailFocus,
     setEmailFocus,
   } = useSignupFormState();
+
+  const { mutate: postCheckEmailData } = useMutation(postCheckEmail, {
+    onSuccess: (data) => {
+      const passMessage = data.data.message;
+      alert(passMessage);
+    },
+    onError: (error) => {
+      if (isAxiosError<ResponseDataType>(error)) {
+        if (error.response) {
+          const errorMessage = error.response?.data.message;
+          alert(errorMessage);
+        }
+      }
+    },
+  });
 
   // setName
   function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -87,8 +106,10 @@ export default function NameEmail() {
     name && email && isName && isEmail ? setIsActive(true) : setIsActive(false);
   }, [name, email, isName, isEmail]);
 
-  // 이메일 중복 확인
-  function checkEmailDuplicate() {}
+  // 이메일 중복 확인 버튼 실행
+  function checkEmailDuplicate() {
+    postCheckEmailData(email);
+  }
 
   return (
     <>

--- a/src/components/signup/NameEmail.tsx
+++ b/src/components/signup/NameEmail.tsx
@@ -24,8 +24,6 @@ import EmailDuplicatedModal from "./EmailDuplicatedModal";
 export default function NameEmail() {
   const [newUser, setNewUser] = useRecoilState(newUserData);
   const setStep = useSetRecoilState(stepNum);
-  const [modalMessage, setModalMessage] = useState("");
-  const [modalOpened, setModalOpened] = useState(false);
 
   const {
     name,
@@ -42,6 +40,10 @@ export default function NameEmail() {
     setNameFocus,
     emailFocus,
     setEmailFocus,
+    modalMessage,
+    setModalMessage,
+    modalOpened,
+    setModalOpened,
   } = useSignupFormState();
 
   const { mutate: postCheckEmailData } = useMutation(postCheckEmail, {

--- a/src/components/signup/NameEmail.tsx
+++ b/src/components/signup/NameEmail.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { styled } from "styled-components";
 import { useRecoilState, useSetRecoilState } from "recoil";
 import { useMutation } from "react-query";
@@ -19,10 +19,13 @@ import SignupTitleLayout from "./SignupTitleLayout";
 import TextLabelLayout from "./TextLabelLayout";
 import useSignupFormState from "../../hooks/useSignupFormState";
 import EmailCheckButton from "./EmailCheckButton";
+import EmailDuplicatedModal from "./EmailDuplicatedModal";
 
 export default function NameEmail() {
   const [newUser, setNewUser] = useRecoilState(newUserData);
   const setStep = useSetRecoilState(stepNum);
+  const [modalMessage, setModalMessage] = useState("");
+  const [modalOpened, setModalOpened] = useState(false);
 
   const {
     name,
@@ -43,14 +46,14 @@ export default function NameEmail() {
 
   const { mutate: postCheckEmailData } = useMutation(postCheckEmail, {
     onSuccess: (data) => {
-      const passMessage = data.data.message;
-      alert(passMessage);
+      setModalMessage(data.data.message);
+      setIsActive(true);
     },
     onError: (error) => {
       if (isAxiosError<ResponseDataType>(error)) {
         if (error.response) {
-          const errorMessage = error.response?.data.message;
-          alert(errorMessage);
+          setModalMessage(error.response?.data.message);
+          setIsActive(false);
         }
       }
     },
@@ -101,18 +104,21 @@ export default function NameEmail() {
 
     // 이름 정규식 확인
     name.length > 1 ? setIsName(true) : setIsName(false);
-
-    // 이메일, 이름 입력 및 정규식 확인 : 버튼 활성화
-    name && email && isName && isEmail ? setIsActive(true) : setIsActive(false);
-  }, [name, email, isName, isEmail]);
+  }, [name, email, isName, isEmail, modalMessage]);
 
   // 이메일 중복 확인 버튼 실행
   function checkEmailDuplicate() {
     postCheckEmailData(email);
+    setModalOpened(true);
+  }
+
+  function handleCloseModal() {
+    setModalOpened(false);
   }
 
   return (
     <>
+      {modalOpened ? <EmailDuplicatedModal handleCloseModal={handleCloseModal} modalMessage={modalMessage} /> : null}
       <ProgressBar progress={50} />
       <BackButtonWrapper>
         <BackButton />

--- a/src/components/signup/NameEmail.tsx
+++ b/src/components/signup/NameEmail.tsx
@@ -14,6 +14,7 @@ import RegexField from "./RegexField";
 import SignupTitleLayout from "./SignupTitleLayout";
 import TextLabelLayout from "./TextLabelLayout";
 import useSignupFormState from "../../hooks/useSignupFormState";
+import EmailCheckButton from "./EmailCheckButton";
 
 export default function NameEmail() {
   const [newUser, setNewUser] = useRecoilState(newUserData);
@@ -86,6 +87,9 @@ export default function NameEmail() {
     name && email && isName && isEmail ? setIsActive(true) : setIsActive(false);
   }, [name, email, isName, isEmail]);
 
+  // 이메일 중복 확인
+  function checkEmailDuplicate() {}
+
   return (
     <>
       <ProgressBar progress={50} />
@@ -109,13 +113,16 @@ export default function NameEmail() {
 
         <InputEmailWrapper $isEmail={isEmail} $emailFocus={emailFocus}>
           <TextLabelLayout labelText={SIGNUP_FIELD_LABEL.email} />
-          <Inputfield
-            onFocus={() => setEmailFocus(true)}
-            onBlur={() => setEmailFocus(false)}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleEmailChange(e)}
-            type="text"
-            placeholder={PLACEHOLDER_TEXT.emailHolder}
-          />
+          <EmailCheckButtonWrapper>
+            <Inputfield
+              onFocus={() => setEmailFocus(true)}
+              onBlur={() => setEmailFocus(false)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleEmailChange(e)}
+              type="text"
+              placeholder={PLACEHOLDER_TEXT.emailHolder}
+            />
+            <EmailCheckButton text="중복확인" emailTyped={isEmail} onClick={checkEmailDuplicate} />
+          </EmailCheckButtonWrapper>
         </InputEmailWrapper>
         {emailRegex()}
       </Container>
@@ -162,6 +169,7 @@ const InputEmailWrapper = styled.div<{ $emailFocus: boolean; $isEmail: boolean }
 `;
 
 const Inputfield = styled.input`
+  width: 20rem;
   padding: 0;
   height: 2rem;
   margin-top: 1em;
@@ -173,6 +181,12 @@ const Inputfield = styled.input`
     color: ${({ theme }) => theme.colors.grey400};
     ${({ theme }) => theme.fonts.title03};
   }
+`;
+
+const EmailCheckButtonWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 `;
 
 const BackButtonWrapper = styled.div`

--- a/src/components/signup/NameEmail.tsx
+++ b/src/components/signup/NameEmail.tsx
@@ -1,6 +1,10 @@
 import { useEffect } from "react";
-import { useRecoilState, useSetRecoilState } from "recoil";
 import { styled } from "styled-components";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import { useMutation } from "react-query";
+import { isAxiosError } from "axios";
+import { ResponseDataType } from "./AgreeChecking";
+import { postCheckEmail } from "../../api/postCheckEmail";
 import { newUserData, stepNum } from "../../atom/signup/signup";
 import { BUTTON_TEXT } from "../../core/signup/buttonText";
 import { EMAIL_REGEX } from "../../core/signup/regex";
@@ -15,10 +19,6 @@ import SignupTitleLayout from "./SignupTitleLayout";
 import TextLabelLayout from "./TextLabelLayout";
 import useSignupFormState from "../../hooks/useSignupFormState";
 import EmailCheckButton from "./EmailCheckButton";
-import { useMutation } from "react-query";
-import { isAxiosError } from "axios";
-import { ResponseDataType } from "./AgreeChecking";
-import { postCheckEmail } from "../../api/postCheckEmail";
 
 export default function NameEmail() {
   const [newUser, setNewUser] = useRecoilState(newUserData);

--- a/src/hooks/useSignupFormState.ts
+++ b/src/hooks/useSignupFormState.ts
@@ -8,6 +8,9 @@ export default function useSignupFormState() {
   const [isActive, setIsActive] = useState(false);
   const [nameFocus, setNameFocus] = useState(false);
   const [emailFocus, setEmailFocus] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+  const [modalOpened, setModalOpened] = useState(false);
+
   return {
     name,
     setName,
@@ -23,5 +26,9 @@ export default function useSignupFormState() {
     setNameFocus,
     emailFocus,
     setEmailFocus,
+    modalMessage,
+    setModalMessage,
+    modalOpened,
+    setModalOpened,
   };
 }

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,18 +1,24 @@
 import { useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+import { useSetRecoilState } from "recoil";
 import StepRenderer from "../components/signup/StepRenderer";
 import { isCookieAuthenticated, isCookieNull, isLogin } from "../utils/common/isLogined";
-import { useEffect } from "react";
+import { stepNum } from "../atom/signup/signup";
 
 export default function Signup() {
   const navigate = useNavigate();
 
   const LoginChecked = isLogin() || isCookieNull() || isCookieAuthenticated();
 
+  const setStep = useSetRecoilState(stepNum);
+
   useEffect(() => {
     if (LoginChecked) {
       navigate("/home");
+    } else {
+      setStep(1);
     }
-  }, [LoginChecked, navigate]);
+  }, [LoginChecked]);
 
   return <div>{LoginChecked ? null : <StepRenderer />}</div>;
 }

--- a/src/type/SignUp/checkDuplicatedEmailType.ts
+++ b/src/type/SignUp/checkDuplicatedEmailType.ts
@@ -1,0 +1,3 @@
+export interface checkDuplicatedEmailType {
+  email: string;
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #323 

## 💙 작업 내용

- [x] step이 0이 되면 렌더링이 더이상 안되는 버그 수정
- [x] 이메일 확인 버튼,모달과 그에 따른 기능 구현 (따봉 지슈슈야 고마워)

## ✅ PR Point

- 이메일 확인 버튼과 기능 구현
- 로그인 => 회원가입 => 로그인 -> 회원 가입 이동시 렌더링 되지 않는 버그 수정

## 👀 스크린샷 / GIF / 링크

- 양식 미충족시 버튼 비활성화
<img width="582" alt="스크린샷 2023-09-17 18 12 43" src="https://github.com/Gwasuwon-shot/Tutice_Client/assets/65286685/80829e1d-d8ea-4896-8afc-f1ff37262d4d">


- 양식 충족시 버튼 활성화
<img width="582" alt="image" src="https://github.com/Gwasuwon-shot/Tutice_Client/assets/65286685/b7bb42be-60c1-46e2-bb83-bf04c0fc44ff">

- 이메일 사용 불가능 경우
<img width="582" alt="스크린샷 2023-09-17 18 11 19" src="https://github.com/Gwasuwon-shot/Tutice_Client/assets/65286685/bcd4d49a-562a-4f1b-abcb-259318107276">

- 이메일 사용 가능 경우
<img width="582" alt="스크린샷 2023-09-17 18 11 35" src="https://github.com/Gwasuwon-shot/Tutice_Client/assets/65286685/8546bb1e-73ca-4a68-8315-2668358a002b">
