### PR TITLE
fix: 페이지 라우팅 주소 수정

### DIFF
--- a/src/components/EditSchedule/EditDatePicker.tsx
+++ b/src/components/EditSchedule/EditDatePicker.tsx
@@ -4,11 +4,11 @@ import "swiper/swiper.min.css";
 import { Swiper, SwiperSlide } from "swiper/react";
 
 import React from "react";
+import { useRecoilState } from "recoil";
+import styled from "styled-components";
 import SwiperCore from "swiper";
 import { editDateState } from "../../atom/EditSchedule/editDateState";
 import { openDatePickerState } from "../../atom/timePicker/timePicker";
-import styled from "styled-components";
-import { useRecoilState } from "recoil";
 
 interface monthCalenderProps {
   month: number;

--- a/src/components/EditSchedule/EditPageFooter.tsx
+++ b/src/components/EditSchedule/EditPageFooter.tsx
@@ -27,7 +27,7 @@ export default function EditPageFooter() {
 
   const { mutate: patchSchdule } = useMutation(updateSchedule, {
     onSuccess: () => {
-      navigate("/change-schedule");
+      navigate("/schedule");
     },
     onError: (error) => {
       console.log(error);

--- a/src/components/EditSchedule/EditPageLessonInformation.tsx
+++ b/src/components/EditSchedule/EditPageLessonInformation.tsx
@@ -1,10 +1,8 @@
-import { RegularLessonNotebookIc, RegularLessonPencilIc } from "../../assets";
-import { openDatePickerState } from "../../atom/timePicker/timePicker";
-import React from "react";
-import { useMutation } from "react-query";
-import styled from "styled-components";
 import { useRecoilState, useRecoilValue } from "recoil";
+import styled from "styled-components";
+import { RegularLessonNotebookIc, RegularLessonPencilIc } from "../../assets";
 import { editDateState } from "../../atom/EditSchedule/editDateState";
+import { openDatePickerState } from "../../atom/timePicker/timePicker";
 
 export default function LessonInformation() {
   const [isDatePickerOpen, setIsDatePickerOpen] = useRecoilState<boolean>(openDatePickerState);

--- a/src/components/EditSchedule/EditPageStudentInformation.tsx
+++ b/src/components/EditSchedule/EditPageStudentInformation.tsx
@@ -3,8 +3,8 @@ import { STUDENT_COLOR } from "../../core/common/studentColor";
 
 import { useRecoilValue } from "recoil";
 import { RegularLessonStudentIc } from "../../assets";
-import { editSchedule } from "../../atom/EditSchedule/editSchedule";
 import { editLessonIdxState } from "../../atom/EditSchedule/editLessonIdx";
+import { editSchedule } from "../../atom/EditSchedule/editSchedule";
 
 export default function StudentInformation() {
   const { studentName, subject, idx } = useRecoilValue(editSchedule);

--- a/src/components/EditSchedule/EditPageTime.tsx
+++ b/src/components/EditSchedule/EditPageTime.tsx
@@ -38,13 +38,17 @@ export default function EditPageTime() {
           </TimeButton>
         ) : (
           <TimeButton onClick={handlStartTimePicker} $isPickerDone={!isStartPickerOpen}>
-            {Number(selectedTime?.startTime.slice(0, 2)) <= 12 ? (
+            {Number(selectedTime?.startTime.slice(0, 2)) < 12 ? (
               <>
                 오전 {Number(selectedTime?.startTime.slice(0, 2))} {selectedTime?.startTime.slice(2)}
               </>
             ) : (
               <>
-                오후 {Number(selectedTime?.startTime.slice(0, 2)) - 12} {selectedTime?.startTime.slice(2)}
+                오후{" "}
+                {Number(selectedTime?.startTime.slice(0, 2)) === 12
+                  ? 12
+                  : Number(selectedTime?.startTime.slice(0, 2)) - 12}
+                {selectedTime?.startTime.slice(2)}
               </>
             )}
           </TimeButton>
@@ -56,13 +60,15 @@ export default function EditPageTime() {
           </TimeButton>
         ) : (
           <TimeButton onClick={handleFinishTimePicker} $isPickerDone={!isFinishPickerOpen}>
-            {Number(selectedTime?.endTime.slice(0, 2)) <= 12 ? (
+            {Number(selectedTime?.endTime.slice(0, 2)) < 12 ? (
               <>
                 오전 {Number(selectedTime?.endTime.slice(0, 2))} {selectedTime?.endTime.slice(2)}
               </>
             ) : (
               <>
-                오후 {Number(selectedTime?.endTime.slice(0, 2)) - 12} {selectedTime?.endTime.slice(2)}
+                오후{" "}
+                {Number(selectedTime?.endTime.slice(0, 2)) === 12 ? 12 : Number(selectedTime?.endTime.slice(0, 2)) - 12}
+                {selectedTime?.endTime.slice(2)}
               </>
             )}
           </TimeButton>

--- a/src/components/EditSchedule/EditPageTime.tsx
+++ b/src/components/EditSchedule/EditPageTime.tsx
@@ -8,7 +8,6 @@ import styled from "styled-components";
 export default function EditPageTime() {
   const [selectedTime, setSelectedTime] = useRecoilState(editSchedule);
   const { startTime, endTime } = selectedTime;
-
   // 2. 요일 시작, 종료시간 관리
 
   const [isStartPickerOpen, setIsStartPickerOpen] = useRecoilState<boolean>(openStartDetailState);
@@ -39,13 +38,17 @@ export default function EditPageTime() {
           </TimeButton>
         ) : (
           <TimeButton onClick={handlStartTimePicker} $isPickerDone={!isStartPickerOpen}>
-            {Number(selectedTime?.startTime.slice(0, 2)) <= 12 ? (
+            {Number(selectedTime?.startTime.slice(0, 2)) < 12 ? (
               <>
                 오전 {Number(selectedTime?.startTime.slice(0, 2))} {selectedTime?.startTime.slice(2)}
               </>
             ) : (
               <>
-                오후 {Number(selectedTime?.startTime.slice(0, 2)) - 12} {selectedTime?.startTime.slice(2)}
+                오후{" "}
+                {Number(selectedTime?.startTime.slice(0, 2)) === 12
+                  ? 12
+                  : Number(selectedTime?.startTime.slice(0, 2)) - 12}
+                {selectedTime?.startTime.slice(2)}
               </>
             )}
           </TimeButton>
@@ -57,13 +60,15 @@ export default function EditPageTime() {
           </TimeButton>
         ) : (
           <TimeButton onClick={handleFinishTimePicker} $isPickerDone={!isFinishPickerOpen}>
-            {Number(selectedTime?.endTime.slice(0, 2)) <= 12 ? (
+            {Number(selectedTime?.endTime.slice(0, 2)) < 12 ? (
               <>
                 오전 {Number(selectedTime?.endTime.slice(0, 2))} {selectedTime?.endTime.slice(2)}
               </>
             ) : (
               <>
-                오후 {Number(selectedTime?.endTime.slice(0, 2)) - 12} {selectedTime?.endTime.slice(2)}
+                오후{" "}
+                {Number(selectedTime?.endTime.slice(0, 2)) === 12 ? 12 : Number(selectedTime?.endTime.slice(0, 2)) - 12}
+                {selectedTime?.endTime.slice(2)}
               </>
             )}
           </TimeButton>

--- a/src/components/EditSchedule/EditPageTime.tsx
+++ b/src/components/EditSchedule/EditPageTime.tsx
@@ -8,7 +8,6 @@ import styled from "styled-components";
 export default function EditPageTime() {
   const [selectedTime, setSelectedTime] = useRecoilState(editSchedule);
   const { startTime, endTime } = selectedTime;
-
   // 2. 요일 시작, 종료시간 관리
 
   const [isStartPickerOpen, setIsStartPickerOpen] = useRecoilState<boolean>(openStartDetailState);

--- a/src/components/EditSchedule/EditTimePicker.tsx
+++ b/src/components/EditSchedule/EditTimePicker.tsx
@@ -5,10 +5,10 @@ import React, { useState } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { focusDayState, openFinishDetailState, openStartDetailState } from "../../atom/timePicker/timePicker";
 
+import { useRecoilState } from "recoil";
+import styled from "styled-components";
 import SwiperCore from "swiper";
 import { editSchedule } from "../../atom/EditSchedule/editSchedule";
-import styled from "styled-components";
-import { useRecoilState } from "recoil";
 
 interface EditDetailTimePickerPropType {
   setIsActive: React.Dispatch<React.SetStateAction<boolean>>;
@@ -61,9 +61,16 @@ export default function EditDetailTimePicker(props: EditDetailTimePickerPropType
   // 1) 시작 타임피커 완료시
   // problem: 현재 로직에서는, 시작시간을 한번 선택한 이후 다른 시간으로 선택하고자 할때 변경 불가
   function handleConfirmStartTimePicker() {
-    const formattedHour = String(activeHourSlide).padStart(2, "0");
+    const formattedHour =
+      activeHourSlide === 12 && activeAmPmSlide === 0 ? "00" : String(activeHourSlide).padStart(2, "0");
+    // 0: 오전 1:오후
     const startTime =
-      activeAmPmSlide === 0 ? `${formattedHour}:${activeMinuteSlide}` : `${activeHourSlide + 12}:${activeMinuteSlide}`;
+      activeAmPmSlide === 0
+        ? `${formattedHour}:${activeMinuteSlide}`
+        : activeHourSlide === 12
+        ? `12:${activeMinuteSlide}` // PM 12시인 경우 12를 그대로 사용
+        : `${activeHourSlide + 12}:${activeMinuteSlide}`; // 그 외 PM 시간은 12를 더함
+
     setSelectedDays({ ...selectedDays, startTime });
     setIsStartPickerOpen(false);
   }
@@ -78,9 +85,15 @@ export default function EditDetailTimePicker(props: EditDetailTimePickerPropType
 
   // 1) 종료 타임피커 완료시
   function handleConfirmFinishTimePicker() {
-    const formattedHour = String(activeHourSlide).padStart(2, "0");
+    const formattedHour =
+      activeHourSlide === 12 && activeAmPmSlide === 0 ? "00" : String(activeHourSlide).padStart(2, "0");
+    // 0: 오전 1:오후
     const endTime =
-      activeAmPmSlide === 0 ? `${formattedHour}:${activeMinuteSlide}` : `${activeHourSlide + 12}:${activeMinuteSlide}`;
+      activeAmPmSlide === 0
+        ? `${formattedHour}:${activeMinuteSlide}`
+        : activeHourSlide === 12
+        ? `12:${activeMinuteSlide}`
+        : `${activeHourSlide + 12}:${activeMinuteSlide}`;
     setSelectedDays({ ...selectedDays, endTime });
     setIsFinishPickerOpen(false);
     setIsActive(true);

--- a/src/components/EditSchedule/EditTimePicker.tsx
+++ b/src/components/EditSchedule/EditTimePicker.tsx
@@ -61,9 +61,16 @@ export default function EditDetailTimePicker(props: EditDetailTimePickerPropType
   // 1) 시작 타임피커 완료시
   // problem: 현재 로직에서는, 시작시간을 한번 선택한 이후 다른 시간으로 선택하고자 할때 변경 불가
   function handleConfirmStartTimePicker() {
-    const formattedHour = String(activeHourSlide).padStart(2, "0");
+    const formattedHour =
+      activeHourSlide === 12 && activeAmPmSlide === 0 ? "00" : String(activeHourSlide).padStart(2, "0");
+    // 0: 오전 1:오후
     const startTime =
-      activeAmPmSlide === 0 ? `${formattedHour}:${activeMinuteSlide}` : `${activeHourSlide + 12}:${activeMinuteSlide}`;
+      activeAmPmSlide === 0
+        ? `${formattedHour}:${activeMinuteSlide}`
+        : activeHourSlide === 12
+        ? `12:${activeMinuteSlide}` // PM 12시인 경우 12를 그대로 사용
+        : `${activeHourSlide + 12}:${activeMinuteSlide}`; // 그 외 PM 시간은 12를 더함
+
     setSelectedDays({ ...selectedDays, startTime });
     setIsStartPickerOpen(false);
   }
@@ -78,9 +85,15 @@ export default function EditDetailTimePicker(props: EditDetailTimePickerPropType
 
   // 1) 종료 타임피커 완료시
   function handleConfirmFinishTimePicker() {
-    const formattedHour = String(activeHourSlide).padStart(2, "0");
+    const formattedHour =
+      activeHourSlide === 12 && activeAmPmSlide === 0 ? "00" : String(activeHourSlide).padStart(2, "0");
+    // 0: 오전 1:오후
     const endTime =
-      activeAmPmSlide === 0 ? `${formattedHour}:${activeMinuteSlide}` : `${activeHourSlide + 12}:${activeMinuteSlide}`;
+      activeAmPmSlide === 0
+        ? `${formattedHour}:${activeMinuteSlide}`
+        : activeHourSlide === 12
+        ? `12:${activeMinuteSlide}`
+        : `${activeHourSlide + 12}:${activeMinuteSlide}`;
     setSelectedDays({ ...selectedDays, endTime });
     setIsFinishPickerOpen(false);
     setIsActive(true);

--- a/src/components/EditSchedule/EditTimePicker.tsx
+++ b/src/components/EditSchedule/EditTimePicker.tsx
@@ -5,10 +5,10 @@ import React, { useState } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { focusDayState, openFinishDetailState, openStartDetailState } from "../../atom/timePicker/timePicker";
 
+import { useRecoilState } from "recoil";
+import styled from "styled-components";
 import SwiperCore from "swiper";
 import { editSchedule } from "../../atom/EditSchedule/editSchedule";
-import styled from "styled-components";
-import { useRecoilState } from "recoil";
 
 interface EditDetailTimePickerPropType {
   setIsActive: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/components/EditSchedule/Header.tsx
+++ b/src/components/EditSchedule/Header.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
-import { RegisterLessonHeaderIc } from "../../assets";
 import styled from "styled-components";
+import { RegisterLessonHeaderIc } from "../../assets";
 
 export default function Header() {
   const navigate = useNavigate();

--- a/src/components/RegularLesson/SelectedDayAndTime.tsx
+++ b/src/components/RegularLesson/SelectedDayAndTime.tsx
@@ -1,134 +1,125 @@
-import {
-    cycleNumberState,
-    dateState,
-    dayState,
-    firstLessonDay,
-    focusDayState,
-    openFinishDetailState,
-    openStartDetailState,
-    temporarySchedule,
-} from "../../atom/timePicker/timePicker";
-import {useRecoilState, useRecoilValue} from 'recoil';
+import { useRecoilState } from "recoil";
+import { dayState, focusDayState, openFinishDetailState, openStartDetailState } from "../../atom/timePicker/timePicker";
 
-import React from 'react';
-import {RegularLessonGroupIc} from "../../assets";
-import styled from 'styled-components';
+import styled from "styled-components";
 
 interface selectedProps {
-    dayofweek : string;
-    startTime : string;
-    endTime : string;
+  dayofweek: string;
+  startTime: string;
+  endTime: string;
 }
 
-export default function SelectedDayAndTime(props : selectedProps) {
+export default function SelectedDayAndTime(props: selectedProps) {
+  const { dayofweek, startTime, endTime } = props;
+  const [selectedDays, setSelectedDays] = useRecoilState(dayState);
+  const [focusDay, setFocusDay] = useRecoilState(focusDayState);
 
-    const { dayofweek, startTime, endTime } = props;
-    const [selectedDays, setSelectedDays] = useRecoilState(dayState);
-    const [focusDay, setFocusDay] = useRecoilState(focusDayState);
+  const focusingDay = selectedDays.find((selectedDay) => selectedDay.dayOfWeek === dayofweek);
 
-    
-    const focusingDay = selectedDays.find((selectedDay) => selectedDay.dayOfWeek === dayofweek);
-    
-    const [isStartPickerOpen, setIsStartPickerOpen] = useRecoilState<boolean>(openStartDetailState);
+  const [isStartPickerOpen, setIsStartPickerOpen] = useRecoilState<boolean>(openStartDetailState);
 
-    function handlStartTimePicker() {
-        setFocusDay(dayofweek)
-        setIsStartPickerOpen(true);
-    }
+  function handlStartTimePicker() {
+    setFocusDay(dayofweek);
+    setIsStartPickerOpen(true);
+  }
 
-    const [isFinishPickerOpen, setIsFinishPickerOpen] = useRecoilState<boolean>(openFinishDetailState);
+  const [isFinishPickerOpen, setIsFinishPickerOpen] = useRecoilState<boolean>(openFinishDetailState);
 
-    function handleFinishTimePicker() {
-        setFocusDay(dayofweek)
-        setIsFinishPickerOpen(true);
-    }
-  
+  function handleFinishTimePicker() {
+    setFocusDay(dayofweek);
+    setIsFinishPickerOpen(true);
+  }
 
-    return (
-        <SelectedWrapper>
-            <DayWrapper> {dayofweek}요일 </DayWrapper>
-            <TimeWrapper> 
-                <Time>
-                    <TimeInfo> 시작 </TimeInfo>
-                    <DetailTime onClick={handlStartTimePicker}>
-                        {Number(focusingDay?.startTime.slice(0, 2)) <= 12 ? (
-                        <>
-                            오전 {Number(focusingDay?.startTime.slice(0, 2))}시 {focusingDay?.startTime.slice(3)}분
-                        </>
-                        ) : (
-                        <>
-                            오후 {Number(focusingDay?.startTime.slice(0, 2)) - 12}시 {focusingDay?.startTime.slice(3)}분
-                        </>
-                        )}
-                    </DetailTime>
-                </Time>
-                <Time>
-                    <TimeInfo> 종료 </TimeInfo>
-                    <DetailTime onClick={handleFinishTimePicker}>
-                        {Number(focusingDay?.endTime.slice(0, 2)) <= 12 ? (
-                        <>
-                            오전 {Number(focusingDay?.endTime.slice(0, 2))}시 {focusingDay?.endTime.slice(3)}분
-                        </>
-                        ) : (
-                        <>
-                            오후 {Number(focusingDay?.endTime.slice(0, 2)) - 12}시 {focusingDay?.endTime.slice(3)}분
-                        </>
-                        )}
-                    </DetailTime>
-                </Time>
-            </TimeWrapper>            
-        </SelectedWrapper>
-    );
+  return (
+    <SelectedWrapper>
+      <DayWrapper> {dayofweek}요일 </DayWrapper>
+      <TimeWrapper>
+        <Time>
+          <TimeInfo> 시작 </TimeInfo>
+          <DetailTime onClick={handlStartTimePicker}>
+            {Number(focusingDay?.startTime.slice(0, 2)) < 12 ? (
+              <>
+                오전 {Number(focusingDay?.startTime.slice(0, 2))}시 {focusingDay?.startTime.slice(3)}분
+              </>
+            ) : (
+              <>
+                오후{" "}
+                {Number(focusingDay?.startTime.slice(0, 2)) === 12
+                  ? 12
+                  : Number(focusingDay?.startTime.slice(0, 2)) - 12}
+                시 {focusingDay?.startTime.slice(3)}분
+              </>
+            )}
+          </DetailTime>
+        </Time>
+        <Time>
+          <TimeInfo> 종료 </TimeInfo>
+          <DetailTime onClick={handleFinishTimePicker}>
+            {Number(focusingDay?.endTime.slice(0, 2)) < 12 ? (
+              <>
+                오전 {Number(focusingDay?.endTime.slice(0, 2))}시 {focusingDay?.endTime.slice(3)}분
+              </>
+            ) : (
+              <>
+                오후{" "}
+                {Number(focusingDay?.endTime.slice(0, 2)) === 12 ? 12 : Number(focusingDay?.endTime.slice(0, 2)) - 12}시{" "}
+                {focusingDay?.endTime.slice(3)}분
+              </>
+            )}
+          </DetailTime>
+        </Time>
+      </TimeWrapper>
+    </SelectedWrapper>
+  );
 }
 
 const SelectedWrapper = styled.article`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    gap: 0.8rem;
-    width: 29.2rem;
-    height: 8rem;
-    padding: 0.9rem;
-    margin-left: 1.5rem;
-    margin-right: 1.5rem;
-    margin-bottom: 0.4rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.8rem;
+  width: 29.2rem;
+  height: 8rem;
+  padding: 0.9rem;
+  margin-left: 1.5rem;
+  margin-right: 1.5rem;
+  margin-bottom: 0.4rem;
 
-    border-radius: 7px;
-    background-color: ${({ theme }) => theme.colors.green1}; 
-    color: ${({ theme }) => theme.colors.green5}; 
-`
+  border-radius: 7px;
+  background-color: ${({ theme }) => theme.colors.green1};
+  color: ${({ theme }) => theme.colors.green5};
+`;
 
 const DayWrapper = styled.div`
-    display: flex;
-    width: 5rem;
-    ${({ theme }) => theme.fonts.body03}; 
-    color: ${({ theme }) => theme.colors.green5}; 
-`
+  display: flex;
+  width: 5rem;
+  ${({ theme }) => theme.fonts.body03};
+  color: ${({ theme }) => theme.colors.green5};
+`;
 
 const TimeWrapper = styled.div`
-    display: flex;
-    gap: 1rem;
-    width: 28rem;
-`
+  display: flex;
+  gap: 1rem;
+  width: 28rem;
+`;
 
 const Time = styled.div`
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 0.7rem;
-    width: 13rem;
-    height: 3.4rem;
-    background-color: ${({ theme }) => theme.colors.green2}; 
-    border-radius: 7px;
-`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.7rem;
+  width: 13rem;
+  height: 3.4rem;
+  background-color: ${({ theme }) => theme.colors.green2};
+  border-radius: 7px;
+`;
 
 const TimeInfo = styled.p`
-    ${({ theme }) => theme.fonts.body04}; 
-    color: ${({ theme }) => theme.colors.grey0}; 
-`
+  ${({ theme }) => theme.fonts.body04};
+  color: ${({ theme }) => theme.colors.grey0};
+`;
 
 const DetailTime = styled.p`
-    ${({ theme }) => theme.fonts.body04}; 
-    color: ${({ theme }) => theme.colors.green5}; 
-`
-
+  ${({ theme }) => theme.fonts.body04};
+  color: ${({ theme }) => theme.colors.green5};
+`;

--- a/src/components/RegularLesson/SelectedDayAndTime.tsx
+++ b/src/components/RegularLesson/SelectedDayAndTime.tsx
@@ -1,48 +1,34 @@
-import {
-    cycleNumberState,
-    dateState,
-    dayState,
-    firstLessonDay,
-    focusDayState,
-    openFinishDetailState,
-    openStartDetailState,
-    temporarySchedule,
-} from "../../atom/timePicker/timePicker";
-import {useRecoilState, useRecoilValue} from 'recoil';
+import { useRecoilState } from "recoil";
+import { dayState, focusDayState, openFinishDetailState, openStartDetailState } from "../../atom/timePicker/timePicker";
 
-import React from 'react';
-import {RegularLessonGroupIc} from "../../assets";
-import styled from 'styled-components';
+import styled from "styled-components";
 
 interface selectedProps {
-    dayofweek : string;
-    startTime : string;
-    endTime : string;
+  dayofweek: string;
+  startTime: string;
+  endTime: string;
 }
 
-export default function SelectedDayAndTime(props : selectedProps) {
-
+export default function SelectedDayAndTime(props: selectedProps) {
     const { dayofweek, startTime, endTime } = props;
     const [selectedDays, setSelectedDays] = useRecoilState(dayState);
     const [focusDay, setFocusDay] = useRecoilState(focusDayState);
-
     
     const focusingDay = selectedDays.find((selectedDay) => selectedDay.dayOfWeek === dayofweek);
     
     const [isStartPickerOpen, setIsStartPickerOpen] = useRecoilState<boolean>(openStartDetailState);
 
     function handlStartTimePicker() {
-        setFocusDay(dayofweek)
+    setFocusDay(dayofweek);
         setIsStartPickerOpen(true);
     }
 
     const [isFinishPickerOpen, setIsFinishPickerOpen] = useRecoilState<boolean>(openFinishDetailState);
 
     function handleFinishTimePicker() {
-        setFocusDay(dayofweek)
+    setFocusDay(dayofweek);
         setIsFinishPickerOpen(true);
     }
-  
 
     return (
         <SelectedWrapper>
@@ -96,20 +82,20 @@ const SelectedWrapper = styled.article`
     border-radius: 7px;
     background-color: ${({ theme }) => theme.colors.green1}; 
     color: ${({ theme }) => theme.colors.green5}; 
-`
+`;
 
 const DayWrapper = styled.div`
     display: flex;
     width: 5rem;
     ${({ theme }) => theme.fonts.body03}; 
     color: ${({ theme }) => theme.colors.green5}; 
-`
+`;
 
 const TimeWrapper = styled.div`
     display: flex;
     gap: 1rem;
     width: 28rem;
-`
+`;
 
 const Time = styled.div`
     display: flex;
@@ -120,15 +106,14 @@ const Time = styled.div`
     height: 3.4rem;
     background-color: ${({ theme }) => theme.colors.green2}; 
     border-radius: 7px;
-`
+`;
 
 const TimeInfo = styled.p`
     ${({ theme }) => theme.fonts.body04}; 
     color: ${({ theme }) => theme.colors.grey0}; 
-`
+`;
 
 const DetailTime = styled.p`
     ${({ theme }) => theme.fonts.body04}; 
     color: ${({ theme }) => theme.colors.green5}; 
-`
-
+`;

--- a/src/components/RegularLesson/SelectedDayAndTime.tsx
+++ b/src/components/RegularLesson/SelectedDayAndTime.tsx
@@ -10,110 +10,116 @@ interface selectedProps {
 }
 
 export default function SelectedDayAndTime(props: selectedProps) {
-    const { dayofweek, startTime, endTime } = props;
-    const [selectedDays, setSelectedDays] = useRecoilState(dayState);
-    const [focusDay, setFocusDay] = useRecoilState(focusDayState);
-    
-    const focusingDay = selectedDays.find((selectedDay) => selectedDay.dayOfWeek === dayofweek);
-    
-    const [isStartPickerOpen, setIsStartPickerOpen] = useRecoilState<boolean>(openStartDetailState);
+  const { dayofweek, startTime, endTime } = props;
+  const [selectedDays, setSelectedDays] = useRecoilState(dayState);
+  const [focusDay, setFocusDay] = useRecoilState(focusDayState);
 
-    function handlStartTimePicker() {
+  const focusingDay = selectedDays.find((selectedDay) => selectedDay.dayOfWeek === dayofweek);
+
+  const [isStartPickerOpen, setIsStartPickerOpen] = useRecoilState<boolean>(openStartDetailState);
+
+  function handlStartTimePicker() {
     setFocusDay(dayofweek);
-        setIsStartPickerOpen(true);
-    }
+    setIsStartPickerOpen(true);
+  }
 
-    const [isFinishPickerOpen, setIsFinishPickerOpen] = useRecoilState<boolean>(openFinishDetailState);
+  const [isFinishPickerOpen, setIsFinishPickerOpen] = useRecoilState<boolean>(openFinishDetailState);
 
-    function handleFinishTimePicker() {
+  function handleFinishTimePicker() {
     setFocusDay(dayofweek);
-        setIsFinishPickerOpen(true);
-    }
+    setIsFinishPickerOpen(true);
+  }
 
-    return (
-        <SelectedWrapper>
-            <DayWrapper> {dayofweek}요일 </DayWrapper>
-            <TimeWrapper> 
-                <Time>
-                    <TimeInfo> 시작 </TimeInfo>
-                    <DetailTime onClick={handlStartTimePicker}>
-                        {Number(focusingDay?.startTime.slice(0, 2)) <= 12 ? (
-                        <>
-                            오전 {Number(focusingDay?.startTime.slice(0, 2))}시 {focusingDay?.startTime.slice(3)}분
-                        </>
-                        ) : (
-                        <>
-                            오후 {Number(focusingDay?.startTime.slice(0, 2)) - 12}시 {focusingDay?.startTime.slice(3)}분
-                        </>
-                        )}
-                    </DetailTime>
-                </Time>
-                <Time>
-                    <TimeInfo> 종료 </TimeInfo>
-                    <DetailTime onClick={handleFinishTimePicker}>
-                        {Number(focusingDay?.endTime.slice(0, 2)) <= 12 ? (
-                        <>
-                            오전 {Number(focusingDay?.endTime.slice(0, 2))}시 {focusingDay?.endTime.slice(3)}분
-                        </>
-                        ) : (
-                        <>
-                            오후 {Number(focusingDay?.endTime.slice(0, 2)) - 12}시 {focusingDay?.endTime.slice(3)}분
-                        </>
-                        )}
-                    </DetailTime>
-                </Time>
-            </TimeWrapper>            
-        </SelectedWrapper>
-    );
+  return (
+    <SelectedWrapper>
+      <DayWrapper> {dayofweek}요일 </DayWrapper>
+      <TimeWrapper>
+        <Time>
+          <TimeInfo> 시작 </TimeInfo>
+          <DetailTime onClick={handlStartTimePicker}>
+            {Number(focusingDay?.startTime.slice(0, 2)) < 12 ? (
+              <>
+                오전 {Number(focusingDay?.startTime.slice(0, 2))}시 {focusingDay?.startTime.slice(3)}분
+              </>
+            ) : (
+              <>
+                오후{" "}
+                {Number(focusingDay?.startTime.slice(0, 2)) === 12
+                  ? 12
+                  : Number(focusingDay?.startTime.slice(0, 2)) - 12}
+                시 {focusingDay?.startTime.slice(3)}분
+              </>
+            )}
+          </DetailTime>
+        </Time>
+        <Time>
+          <TimeInfo> 종료 </TimeInfo>
+          <DetailTime onClick={handleFinishTimePicker}>
+            {Number(focusingDay?.endTime.slice(0, 2)) < 12 ? (
+              <>
+                오전 {Number(focusingDay?.endTime.slice(0, 2))}시 {focusingDay?.endTime.slice(3)}분
+              </>
+            ) : (
+              <>
+                오후{" "}
+                {Number(focusingDay?.endTime.slice(0, 2)) === 12 ? 12 : Number(focusingDay?.endTime.slice(0, 2)) - 12}시{" "}
+                {focusingDay?.endTime.slice(3)}분
+              </>
+            )}
+          </DetailTime>
+        </Time>
+      </TimeWrapper>
+    </SelectedWrapper>
+  );
 }
 
 const SelectedWrapper = styled.article`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    gap: 0.8rem;
-    width: 29.2rem;
-    height: 8rem;
-    padding: 0.9rem;
-    margin-left: 1.5rem;
-    margin-right: 1.5rem;
-    margin-bottom: 0.4rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.8rem;
+  width: 29.2rem;
+  height: 8rem;
+  padding: 0.9rem;
+  margin-left: 1.5rem;
+  margin-right: 1.5rem;
+  margin-bottom: 0.4rem;
 
-    border-radius: 7px;
-    background-color: ${({ theme }) => theme.colors.green1}; 
-    color: ${({ theme }) => theme.colors.green5}; 
+  border-radius: 7px;
+  background-color: ${({ theme }) => theme.colors.green1};
+  color: ${({ theme }) => theme.colors.green5};
 `;
 
 const DayWrapper = styled.div`
-    display: flex;
-    width: 5rem;
-    ${({ theme }) => theme.fonts.body03}; 
-    color: ${({ theme }) => theme.colors.green5}; 
+  display: flex;
+  width: 5rem;
+  ${({ theme }) => theme.fonts.body03};
+  color: ${({ theme }) => theme.colors.green5};
 `;
 
 const TimeWrapper = styled.div`
-    display: flex;
-    gap: 1rem;
-    width: 28rem;
+  display: flex;
+  gap: 1rem;
+  width: 28rem;
 `;
 
 const Time = styled.div`
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 0.7rem;
-    width: 13rem;
-    height: 3.4rem;
-    background-color: ${({ theme }) => theme.colors.green2}; 
-    border-radius: 7px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.7rem;
+  width: 13rem;
+  height: 3.4rem;
+  background-color: ${({ theme }) => theme.colors.green2};
+  border-radius: 7px;
 `;
 
 const TimeInfo = styled.p`
-    ${({ theme }) => theme.fonts.body04}; 
-    color: ${({ theme }) => theme.colors.grey0}; 
+  ${({ theme }) => theme.fonts.body04};
+  color: ${({ theme }) => theme.colors.grey0};
 `;
 
 const DetailTime = styled.p`
-    ${({ theme }) => theme.fonts.body04}; 
-    color: ${({ theme }) => theme.colors.green5}; 
+  ${({ theme }) => theme.fonts.body04};
+  color: ${({ theme }) => theme.colors.green5};
 `;

--- a/src/components/RegularLesson/TimePicker/DatePicker.tsx
+++ b/src/components/RegularLesson/TimePicker/DatePicker.tsx
@@ -4,9 +4,9 @@ import "swiper/swiper.min.css";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { dateState, dayState, firstLessonDay, openDatePickerState } from "../../../atom/timePicker/timePicker";
 
-import SwiperCore from "swiper";
-import styled from "styled-components";
 import { useRecoilState } from "recoil";
+import styled from "styled-components";
+import SwiperCore from "swiper";
 
 interface monthCalenderProps {
   month: number;
@@ -74,7 +74,7 @@ export default function DatePicker() {
   const [activeSlide, setActiveSlide] = useRecoilState(dateState);
   const [firstLesson, setfirstLesson] = useRecoilState(firstLessonDay);
   const [selectedDays, setSelectedDays] = useRecoilState(dayState);
-  
+
   function handleSlideChange(swiper: SwiperCore) {
     setActiveSlide({
       year: currentYear,
@@ -103,7 +103,7 @@ export default function DatePicker() {
       if (existingDayIndex === -1) {
         return [...prevSelectedDays, { dayOfWeek: day, startTime: "12:00", endTime: "12:00" }];
       } else {
-        return [...prevSelectedDays]
+        return [...prevSelectedDays];
       }
     });
   }

--- a/src/components/RegularLesson/TimePicker/DetailTimePicker.tsx
+++ b/src/components/RegularLesson/TimePicker/DetailTimePicker.tsx
@@ -9,10 +9,10 @@ import {
   openStartDetailState,
 } from "../../../atom/timePicker/timePicker";
 
-import SwiperCore from "swiper";
-import styled from "styled-components";
-import { useRecoilState } from "recoil";
 import { useState } from "react";
+import { useRecoilState } from "recoil";
+import styled from "styled-components";
+import SwiperCore from "swiper";
 
 export default function DetailTimePicker() {
   // 1. 오전 오후 관리

--- a/src/components/RegularLesson/TimePicker/DetailTimePicker.tsx
+++ b/src/components/RegularLesson/TimePicker/DetailTimePicker.tsx
@@ -9,10 +9,10 @@ import {
   openStartDetailState,
 } from "../../../atom/timePicker/timePicker";
 
-import SwiperCore from "swiper";
-import styled from "styled-components";
-import { useRecoilState } from "recoil";
 import { useState } from "react";
+import { useRecoilState } from "recoil";
+import styled from "styled-components";
+import SwiperCore from "swiper";
 
 export default function DetailTimePicker() {
   // 1. 오전 오후 관리
@@ -50,7 +50,9 @@ export default function DetailTimePicker() {
   }
 
   // 2) swiper
-  const slidesMinute = Array.from({ length: 2 }, (_, index) => <SwiperSlide key={index}>{MINUTES[index]}분</SwiperSlide>);
+  const slidesMinute = Array.from({ length: 2 }, (_, index) => (
+    <SwiperSlide key={index}>{MINUTES[index]}분</SwiperSlide>
+  ));
 
   // 4. 시작시간 상태관리
   const [isStartPickerOpen, setIsStartPickerOpen] = useRecoilState<boolean>(openStartDetailState);
@@ -59,16 +61,18 @@ export default function DetailTimePicker() {
 
   // 1) 시작 타임피커 완료시
   function handleConfirmStartTimePicker() {
-    const formattedHour = String(activeHourSlide).padStart(2, "0");
-    let newStartTime =
-      activeAmPmSlide === 0 ? `${formattedHour}:${activeMinuteSlide}` : `${activeHourSlide + 12}:${activeMinuteSlide}`;
-    if (newStartTime === "24:00")
-      newStartTime = "00:00";
+    const formattedHour =
+      activeHourSlide === 12 && activeAmPmSlide === 0 ? "00" : String(activeHourSlide).padStart(2, "0");
+
+    const newStartTime =
+      activeAmPmSlide === 0
+        ? `${formattedHour}:${activeMinuteSlide}`
+        : activeHourSlide === 12
+        ? `12:${activeMinuteSlide}`
+        : `${activeHourSlide + 12}`;
     setSelectedDays((prevSelectedDays) =>
-    prevSelectedDays.map((day) =>
-      day.dayOfWeek === focusDay ? { ...day, startTime: newStartTime } : day
-    )
-  );
+      prevSelectedDays.map((day) => (day.dayOfWeek === focusDay ? { ...day, startTime: newStartTime } : day)),
+    );
     setFocusDay("");
     setIsStartPickerOpen(false);
   }
@@ -83,17 +87,18 @@ export default function DetailTimePicker() {
 
   // 1) 종료 타임피커 완료시
   function handleConfirmFinishTimePicker() {
-    const formattedHour = String(activeHourSlide).padStart(2, "0");
-    let newEndTime =
-      activeAmPmSlide === 0 ? `${formattedHour}:${activeMinuteSlide}` : `${activeHourSlide + 12}:${activeMinuteSlide}`;
-    if (newEndTime === "24:00")
-      newEndTime = "00:00";
+    const formattedHour =
+      activeHourSlide === 12 && activeAmPmSlide === 0 ? "00" : String(activeHourSlide).padStart(2, "0");
+    const newEndTime =
+      activeAmPmSlide === 0
+        ? `${formattedHour}:${activeMinuteSlide}`
+        : activeHourSlide === 12
+        ? `12:${activeMinuteSlide}`
+        : `${activeHourSlide + 12}:${activeMinuteSlide}`;
     setSelectedDays((prevSelectedDays) =>
-      prevSelectedDays.map((day) =>
-        day.dayOfWeek === focusDay ? { ...day, endTime: newEndTime } : day
-      )
+      prevSelectedDays.map((day) => (day.dayOfWeek === focusDay ? { ...day, endTime: newEndTime } : day)),
     );
-    
+
     setFocusDay("");
     setIsFinishPickerOpen(false);
   }

--- a/src/components/RegularLesson/TimePicker/DetailTimePicker.tsx
+++ b/src/components/RegularLesson/TimePicker/DetailTimePicker.tsx
@@ -50,7 +50,9 @@ export default function DetailTimePicker() {
   }
 
   // 2) swiper
-  const slidesMinute = Array.from({ length: 2 }, (_, index) => <SwiperSlide key={index}>{MINUTES[index]}분</SwiperSlide>);
+  const slidesMinute = Array.from({ length: 2 }, (_, index) => (
+    <SwiperSlide key={index}>{MINUTES[index]}분</SwiperSlide>
+  ));
 
   // 4. 시작시간 상태관리
   const [isStartPickerOpen, setIsStartPickerOpen] = useRecoilState<boolean>(openStartDetailState);
@@ -70,7 +72,7 @@ export default function DetailTimePicker() {
         : `${activeHourSlide + 12}`;
     setSelectedDays((prevSelectedDays) =>
       prevSelectedDays.map((day) => (day.dayOfWeek === focusDay ? { ...day, startTime: newStartTime } : day)),
-  );
+    );
     setFocusDay("");
     setIsStartPickerOpen(false);
   }
@@ -96,7 +98,7 @@ export default function DetailTimePicker() {
     setSelectedDays((prevSelectedDays) =>
       prevSelectedDays.map((day) => (day.dayOfWeek === focusDay ? { ...day, endTime: newEndTime } : day)),
     );
-    
+
     setFocusDay("");
     setIsFinishPickerOpen(false);
   }

--- a/src/components/RegularLesson/TimePicker/DetailTimePicker.tsx
+++ b/src/components/RegularLesson/TimePicker/DetailTimePicker.tsx
@@ -59,15 +59,17 @@ export default function DetailTimePicker() {
 
   // 1) 시작 타임피커 완료시
   function handleConfirmStartTimePicker() {
-    const formattedHour = String(activeHourSlide).padStart(2, "0");
-    let newStartTime =
-      activeAmPmSlide === 0 ? `${formattedHour}:${activeMinuteSlide}` : `${activeHourSlide + 12}:${activeMinuteSlide}`;
-    if (newStartTime === "24:00")
-      newStartTime = "00:00";
+    const formattedHour =
+      activeHourSlide === 12 && activeAmPmSlide === 0 ? "00" : String(activeHourSlide).padStart(2, "0");
+
+    const newStartTime =
+      activeAmPmSlide === 0
+        ? `${formattedHour}:${activeMinuteSlide}`
+        : activeHourSlide === 12
+        ? `12:${activeMinuteSlide}`
+        : `${activeHourSlide + 12}`;
     setSelectedDays((prevSelectedDays) =>
-    prevSelectedDays.map((day) =>
-      day.dayOfWeek === focusDay ? { ...day, startTime: newStartTime } : day
-    )
+      prevSelectedDays.map((day) => (day.dayOfWeek === focusDay ? { ...day, startTime: newStartTime } : day)),
   );
     setFocusDay("");
     setIsStartPickerOpen(false);
@@ -83,15 +85,16 @@ export default function DetailTimePicker() {
 
   // 1) 종료 타임피커 완료시
   function handleConfirmFinishTimePicker() {
-    const formattedHour = String(activeHourSlide).padStart(2, "0");
-    let newEndTime =
-      activeAmPmSlide === 0 ? `${formattedHour}:${activeMinuteSlide}` : `${activeHourSlide + 12}:${activeMinuteSlide}`;
-    if (newEndTime === "24:00")
-      newEndTime = "00:00";
+    const formattedHour =
+      activeHourSlide === 12 && activeAmPmSlide === 0 ? "00" : String(activeHourSlide).padStart(2, "0");
+    const newEndTime =
+      activeAmPmSlide === 0
+        ? `${formattedHour}:${activeMinuteSlide}`
+        : activeHourSlide === 12
+        ? `12:${activeMinuteSlide}`
+        : `${activeHourSlide + 12}:${activeMinuteSlide}`;
     setSelectedDays((prevSelectedDays) =>
-      prevSelectedDays.map((day) =>
-        day.dayOfWeek === focusDay ? { ...day, endTime: newEndTime } : day
-      )
+      prevSelectedDays.map((day) => (day.dayOfWeek === focusDay ? { ...day, endTime: newEndTime } : day)),
     );
     
     setFocusDay("");

--- a/src/components/RegularLesson/TimePicker/TimePicker.tsx
+++ b/src/components/RegularLesson/TimePicker/TimePicker.tsx
@@ -4,9 +4,9 @@ import "swiper/swiper.min.css";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { cycleNumberState, openTimePickerState } from "../../../atom/timePicker/timePicker";
 
-import SwiperCore from "swiper";
-import styled from "styled-components";
 import { useRecoilState } from "recoil";
+import styled from "styled-components";
+import SwiperCore from "swiper";
 
 export default function TimePicker() {
   // [{'월':['12:00', '13:00']}, ]

--- a/src/components/login/LoginInput.tsx
+++ b/src/components/login/LoginInput.tsx
@@ -7,12 +7,12 @@ import { setCookie } from "../../api/cookie";
 import { postLocalLogin } from "../../api/localLogin";
 import { canViewingLoginIc, viewingLoginIc } from "../../assets";
 import { userRoleData } from "../../atom/loginUser/loginUser";
+import { connectLessonId } from "../../atom/registerLesson/registerLesson";
+import { lessonCode } from "../../atom/share/share";
+import { lessonCodeAndPaymentId } from "../../atom/tuitionPayment/tuitionPayment";
 import RegexField from "../signup/RegexField";
 import TextLabelLayout from "../signup/TextLabelLayout";
 import LoginButton from "./LoginButton";
-import { lessonCode } from "../../atom/share/share";
-import { lessonCodeAndPaymentId } from "../../atom/tuitionPayment/tuitionPayment";
-import { connectLessonId } from "../../atom/registerLesson/registerLesson";
 
 export default function LoginInput() {
   const [userLogin, setUserLogin] = useState({ email: "", password: "" });


### PR DESCRIPTION
1. 유효하지 않은 주소로 라우팅 중이였음
2. 타임 피커에 

## 🔥 Related Issues

- close #395 
- close #397 

## 💙 작업 내용

- [x] 기존페이지에서 api 요청 성공 후 엉뚱한 화면으로 라우팅 됨
- [x] 기존 24:00 12:00에 대한 분기 세부적으로 더 나눔.

## ✅ PR Point

- 기존 코드에서 api 요청 성공 후 "/change-schedule"로 라우팅 되는데 코드 상 해당 페이지로 라우팅되고 있는 페이지가 존재하지 않음. 
- 기존 명세서에서도 수정 완료  캘린더 뷰로 이동하므로 "/schedule"로 라우팅 주소 변경함.

----

- 12:00 24:00에 대한 분기 처리 진행함. QA는 수업 등록의 경우만 있었으나 수업 시간 변경도 동일한 이슈가 발생해 동일 처리함.

- ⚠️ 우선은 급한대로 수정해두었으나 해당 로직 완전히 동일하여 리팩토링 과정에서 새 유틸로 분리 필요함. 로직 개선도 필요.

## 👀 스크린샷 / GIF / 링크

[스케줄 변경 후 > 페이지 흰 화면](https://www.notion.so/class-cha/08d39ba590c34b49925016213c69135b)

[수업 등록이 12:00Pm, 12:30pm 설정이 안된다.](https://www.notion.so/class-cha/39ad56da8ef5408cad6b41f8ee435621?p=ad05677b7a6d461dbee882fbbe0571cf&pm=s)
