### PR TITLE
[ FIX ] 모호한 수정 이벤트 위치 변경

### DIFF
--- a/src/components/EditSchedule/EditPageFooter.tsx
+++ b/src/components/EditSchedule/EditPageFooter.tsx
@@ -27,7 +27,7 @@ export default function EditPageFooter() {
 
   const patchEditDate = String(year) + "-" + String(month).padStart(2, "0") + "-" + String(date).padStart(2, "0");
 
-  const { mutate: patchSchdule } = useMutation(updateSchedule, {
+  const { mutate: patchSchedule } = useMutation(updateSchedule, {
     onSuccess: () => {
       navigate("/schedule");
     },
@@ -41,7 +41,7 @@ export default function EditPageFooter() {
     () => getValidateTimeRange({ startTime, endTime }),
     {
       onSuccess: () => {
-        patchSchdule({
+        patchSchedule({
           idx: idx,
           date: patchEditDate,
           startTime: startTime,

--- a/src/components/EditSchedule/EditPageLessonInformation.tsx
+++ b/src/components/EditSchedule/EditPageLessonInformation.tsx
@@ -19,9 +19,9 @@ export default function LessonInformation() {
       </IconWrapper>
       <LessonWrapper>
         <Turn></Turn>
-        <LessonDate>
+        <LessonDate onClick={handleDatePicker}>
           <LessonDateName> 수업일 </LessonDateName>
-          <LessonDateEditButton type="button" onClick={handleDatePicker}>
+          <LessonDateEditButton type="button">
             {year}년 {month}월 {date}일 {dayOfWeek}요일
           </LessonDateEditButton>
           <RegularLessonPencilIcon />


### PR DESCRIPTION
## 🔥 Related Issues

- close #404 

## 💙 작업 내용

- [x] 텍스트에 달려있던 리슨이벤트를 버튼 위치로 이동

## ✅ PR Point

- 연필 아이콘이 무의미한 아이콘 같아 이벤트 범위를 변경 함

- 겸사겸사 오타 수정도 진행
