### PR TITLE
[ Fix ] 출결 상태를 중복 선택시 값이 활성화되지 않는 문제 해결

### DIFF
--- a/src/components/common/AttendanceCheckModal.tsx
+++ b/src/components/common/AttendanceCheckModal.tsx
@@ -1,10 +1,10 @@
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
 import { attendanceLesson } from "../../atom/attendanceCheck/attendanceLesson";
 import { attendanceStatus } from "../../atom/attendanceCheck/attendanceStatus";
-import { isModalOpen } from "../../atom/common/isModalOpen";
 import { ATTENDANCE_STATUS } from "../../core/common/attendanceStatus";
 import { STUDENT_COLOR } from "../../core/common/studentColor";
+import useModal from "../../hooks/useModal";
 import AttendanceStatusButton from "./AttendanceStatusButton";
 import SubjectLabel from "./SubjectLabel";
 import ToastModal from "./ToastModal";
@@ -16,14 +16,13 @@ interface AttendanceCheckModalProp {
 
 export default function AttendanceCheckModal(props: AttendanceCheckModalProp) {
   const { setIsCheckingModalOpen, isUpdateOpen } = props;
-  const [openModal, setOpenModal] = useRecoilState<boolean>(isModalOpen);
+  const { unShowModal } = useModal();
   const [attendanceData, setAttendanceData] = useRecoilState(attendanceStatus);
-  const [selectedLesson, setSelectedLesson] = useRecoilState(attendanceLesson);
+  const selectedLesson = useRecoilValue(attendanceLesson);
   const { lessonIdx, studentName, count, subject, scheduleIdx } = selectedLesson;
 
   function handleCancelAttendanceCheck() {
-    setAttendanceData({ idx: scheduleIdx, status: "" });
-    setOpenModal(false);
+    unShowModal();
   }
 
   function checkSameSelectedStatus(status: string) {

--- a/src/components/noAttendance/NoCheckAttendanceContanier.tsx
+++ b/src/components/noAttendance/NoCheckAttendanceContanier.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { styled } from "styled-components";
 import { attendanceLesson } from "../../atom/attendanceCheck/attendanceLesson";
 import { STUDENT_COLOR } from "../../core/common/studentColor";
@@ -39,7 +39,7 @@ export default function NoCheckAttendanceContanier(props: NoCheckAttendanceConta
   const { setOpenModal, lesson, schedule } = props;
   const { idx, studentName, subject } = lesson;
   const { startTime, endTime, expectedCount } = schedule;
-  const [selectedLesson, setSelectedLesson] = useRecoilState(attendanceLesson);
+  const setSelectedLesson = useSetRecoilState(attendanceLesson);
 
   function handleAttendanceCheck(): void {
     setSelectedLesson({

--- a/src/components/noAttendance/NoCheckAttendanceContanier.tsx
+++ b/src/components/noAttendance/NoCheckAttendanceContanier.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useSetRecoilState } from "recoil";
 import { styled } from "styled-components";
 import { attendanceLesson } from "../../atom/attendanceCheck/attendanceLesson";
+import { attendanceStatus } from "../../atom/attendanceCheck/attendanceStatus";
 import { STUDENT_COLOR } from "../../core/common/studentColor";
 import { scheduleType } from "../../type/common/scheduleType";
 import NoCheckPageAttendanceButton from "../common/NoCheckPageAttendanceButton";
@@ -40,6 +41,7 @@ export default function NoCheckAttendanceContanier(props: NoCheckAttendanceConta
   const { idx, studentName, subject } = lesson;
   const { startTime, endTime, expectedCount } = schedule;
   const setSelectedLesson = useSetRecoilState(attendanceLesson);
+  const setAttendanceData = useSetRecoilState(attendanceStatus);
 
   function handleAttendanceCheck(): void {
     setSelectedLesson({
@@ -49,6 +51,7 @@ export default function NoCheckAttendanceContanier(props: NoCheckAttendanceConta
       scheduleIdx: schedule?.idx,
       subject: subject,
     });
+    setAttendanceData({ idx: schedule?.idx, status: "" });
     setOpenModal(true);
   }
 

--- a/src/components/noAttendance/NoCheckLesson.tsx
+++ b/src/components/noAttendance/NoCheckLesson.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { styled } from "styled-components";
 import { attendanceLesson } from "../../atom/attendanceCheck/attendanceLesson";
-import { attendanceStatus } from "../../atom/attendanceCheck/attendanceStatus";
 import { isModalOpen } from "../../atom/common/isModalOpen";
 import useGetMissingAttendanceSchedule from "../../hooks/useGetMissingAttendanceSchedule";
 import AttendanceCheckModal from "../common/AttendanceCheckModal";
@@ -39,7 +38,7 @@ interface MissingAttendanceData {
 
 export default function NoCheckLesson() {
   const { missingAttendanceSchedule } = useGetMissingAttendanceSchedule();
-  const [selectedLesson, setSelectedLesson] = useRecoilState(attendanceLesson);
+  const selectedLesson = useRecoilValue(attendanceLesson);
   const [openModal, setOpenModal] = useRecoilState<boolean>(isModalOpen);
   const [isCheckingModalOpen, setIsCheckingModalOpen] = useState<boolean>(false);
 
@@ -50,6 +49,7 @@ export default function NoCheckLesson() {
           missingAttendanceSchedule?.map(
             ({ date, dayOfWeek, missingAttedanceScheduleList }: MissingAttendanceData, idx: number) => {
               return (
+                // TODO: unique key 에러 확인해보기
                 <NoAttendanceContainer key={idx}>
                   <NoAttendanceDate>
                     {new Date(date).getMonth() + 1}월 {new Date(date).getDate()}일 ({dayOfWeek})

--- a/src/components/teacherHome/banner/ClassPreviewBanner.tsx
+++ b/src/components/teacherHome/banner/ClassPreviewBanner.tsx
@@ -136,7 +136,7 @@ const Student = styled.p`
   ${({ theme }) => theme.fonts.title03};
 `;
 
-const ClassStatusWrapper = styled.p`
+const ClassStatusWrapper = styled.div`
   display: flex;
 
   margin-top: 0.3rem;


### PR DESCRIPTION
## 🔥 Related Issues

- close #403 

## 💙 작업 내용

- [x] 버튼 클릭시 수업 정보 갖고 있도록 수정 함

## ✅ PR Point

- 수업 정보 값이 비동기적으로 동작하여 수업 정보 값을 모달이 열리는 동시에 갖도록 함.


