### PR TITLE
[ FEAT ] 수업 목록에서 취소된 회차 건너 뛰고 표기 

### DIFF
--- a/src/api/createLesson.ts
+++ b/src/api/createLesson.ts
@@ -27,7 +27,6 @@ interface createLessonProps {
 export async function createLesson(props: createLessonProps) {
   const { lesson, account } = props;
   const { studentName, subject, payment, amount, count, startDate, regularScheduleList } = lesson;
-  // const { name, bank, number } = account;
   const { bank, number } = account;
 
   const data = await client.post(

--- a/src/components/manageLesson/AttendanceInforms.tsx
+++ b/src/components/manageLesson/AttendanceInforms.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 import { attendanceLesson } from "../../atom/attendanceCheck/attendanceLesson";
 import { isModalOpen } from "../../atom/common/isModalOpen";
+import useOrderedSchedules from "../../hooks/attandanceInforms/useOrderedSchedules";
 import useGetCanceledScheduleByLesson from "../../hooks/manageLessons/useGetCanceledScheduleByLesson";
 import useGetLessonSchedule from "../../hooks/useGetLessonSchedule";
 import { ScheduleListType } from "../../type/manageLesson/scheduleListType";
@@ -26,35 +27,13 @@ export default function AttendanceInforms() {
   const [isCheckingModalOpen, setIsCheckingModalOpen] = useState(false);
   const [isCancelImpossibleModalOpen, setIsCancelImpossibleModalOpen] = useState(false);
   const [isUpdateOpen, setIsUpdateOpen] = useState(false);
-  const [combinedClasses, setCombinedClasses] = useState([]);
-  const [orderedSchedules, setOrderedSchedules] = useState<number[]>([]);
 
   const openModal = useRecoilValue<boolean>(isModalOpen);
   const selectedLesson = useRecoilValue(attendanceLesson);
 
   const { scheduleList } = useGetLessonSchedule(Number(manageLessonId));
   const { cancelScheduleList } = useGetCanceledScheduleByLesson(Number(manageLessonId));
-
-  function orderProceedLessons(schedules: scheduleListType[]) {
-    const totalNonCanceled = schedules.reduce((acc, schedule) => {
-      return acc + (schedule.status !== "취소" ? 1 : 0);
-    }, 0);
-
-    let currentOrder = totalNonCanceled;
-    return schedules.map((schedule) => {
-      if (schedule.status !== "취소") {
-        return currentOrder--;
-      }
-      return 0;
-    });
-  }
-  useEffect(() => {
-    const combined = cancelScheduleList
-      .concat(scheduleList)
-      .sort((a: scheduleListType, b: scheduleListType) => b.idx - a.idx);
-    setCombinedClasses(combined);
-    setOrderedSchedules(orderProceedLessons(combined));
-  }, [cancelScheduleList, scheduleList]);
+  const { orderedSchedules, combinedClasses } = useOrderedSchedules(cancelScheduleList, scheduleList);
 
   function handleCloseCancelImpossibleModal() {
     setIsCancelImpossibleModalOpen(false);
@@ -130,8 +109,6 @@ const GreyBox = styled.div`
 `;
 
 const ScheduleWrapper = styled.section`
-  /* overflow: scroll; */
-
   padding-bottom: 15rem;
 `;
 

--- a/src/components/manageLesson/AttendanceInforms.tsx
+++ b/src/components/manageLesson/AttendanceInforms.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { useRecoilState } from "recoil";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 import { attendanceLesson } from "../../atom/attendanceCheck/attendanceLesson";
 import { isModalOpen } from "../../atom/common/isModalOpen";
 import useGetCanceledScheduleByLesson from "../../hooks/manageLessons/useGetCanceledScheduleByLesson";
-import useGetLessonDetail from "../../hooks/useGetLessonDetail";
 import useGetLessonSchedule from "../../hooks/useGetLessonSchedule";
 import { ScheduleListType } from "../../type/manageLesson/scheduleListType";
 import AttendanceCheckModal from "../common/AttendanceCheckModal";
@@ -27,21 +26,35 @@ export default function AttendanceInforms() {
   const [isCheckingModalOpen, setIsCheckingModalOpen] = useState(false);
   const [isCancelImpossibleModalOpen, setIsCancelImpossibleModalOpen] = useState(false);
   const [isUpdateOpen, setIsUpdateOpen] = useState(false);
+  const [combinedClasses, setCombinedClasses] = useState([]);
+  const [orderedSchedules, setOrderedSchedules] = useState<number[]>([]);
 
-  const [selectedLesson, setSelectedLesson] = useRecoilState(attendanceLesson);
-  const [openModal, setOpenModal] = useRecoilState<boolean>(isModalOpen);
-  const { studentName, subject } = useGetLessonDetail(Number(manageLessonId));
+  const openModal = useRecoilValue<boolean>(isModalOpen);
+  const selectedLesson = useRecoilValue(attendanceLesson);
 
   const { scheduleList } = useGetLessonSchedule(Number(manageLessonId));
   const { cancelScheduleList } = useGetCanceledScheduleByLesson(Number(manageLessonId));
 
-  const combinedClasses = cancelScheduleList
-    .concat(scheduleList)
-    .sort((a: scheduleListType, b: scheduleListType) => b.idx - a.idx);
+  function orderProceedLessons(schedules: scheduleListType[]) {
+    const totalNonCanceled = schedules.reduce((acc, schedule) => {
+      return acc + (schedule.status !== "취소" ? 1 : 0);
+    }, 0);
 
+    let currentOrder = totalNonCanceled;
+    return schedules.map((schedule) => {
+      if (schedule.status !== "취소") {
+        return currentOrder--;
+      }
+      return 0;
+    });
+  }
   useEffect(() => {
-    studentName && subject && setSelectedLesson({ ...selectedLesson, studentName: studentName, subject: subject });
-  }, [studentName, subject]);
+    const combined = cancelScheduleList
+      .concat(scheduleList)
+      .sort((a: scheduleListType, b: scheduleListType) => b.idx - a.idx);
+    setCombinedClasses(combined);
+    setOrderedSchedules(orderProceedLessons(combined));
+  }, [cancelScheduleList, scheduleList]);
 
   function handleCloseCancelImpossibleModal() {
     setIsCancelImpossibleModalOpen(false);
@@ -85,7 +98,7 @@ export default function AttendanceInforms() {
               status={status}
               startTime={startTime}
               endTime={endTime}
-              count={Math.abs(index - scheduleList?.length)}
+              count={orderedSchedules[index]}
               lessonIdx={idx}
               scheduleIdx={idx}
               setIsCancelImpossibleModalOpen={setIsCancelImpossibleModalOpen}

--- a/src/hooks/attandanceInforms/useOrderedSchedules.tsx
+++ b/src/hooks/attandanceInforms/useOrderedSchedules.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { ScheduleListType } from "../../type/manageLesson/scheduleListType";
+
+export default function useOrderedSchedules(cancelScheduleList: ScheduleListType[], scheduleList: ScheduleListType) {
+  const [combinedClasses, setCombinedClasses] = useState<ScheduleListType[]>([]);
+  const [orderedSchedules, setOrderedSchedules] = useState<number[]>([]);
+
+  useEffect(() => {
+    const combined = cancelScheduleList
+      .concat(scheduleList)
+      .sort((a: ScheduleListType, b: ScheduleListType) => b.idx - a.idx);
+    setCombinedClasses(combined);
+    setOrderedSchedules(processAndOrderSchedules(combined));
+  }, [cancelScheduleList, scheduleList]);
+
+  return { orderedSchedules, combinedClasses };
+}
+
+function processAndOrderSchedules(schedules: ScheduleListType[]) {
+  const totalNonCanceled = schedules.reduce((acc, schedule) => {
+    return acc + (schedule.status !== "취소" ? 1 : 0);
+  }, 0);
+
+  let currentOrder = totalNonCanceled;
+  return schedules.map((schedule) => {
+    if (schedule.status !== "취소") {
+      return currentOrder--;
+    }
+    return 0;
+  });
+}

--- a/src/pages/LessonRegisterComplete.tsx
+++ b/src/pages/LessonRegisterComplete.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import styled from "styled-components";
 import { TosCheckedSignupIc } from "../assets";
 import { studentNameState, subjectNameState } from "../atom/common/datePicker";
@@ -22,12 +22,12 @@ export default function LessonRegisterComplete() {
   const [startDate, setStartDate] = useRecoilState(dateState);
   const [regularScheduleList, setRegularScheduleList] = useRecoilState(dayState);
 
-  const [amount, setAmount] = useRecoilState<number>(moneyAmount);
-  const [count, setCount] = useRecoilState<number>(cycleNumberState);
-  const [payment, setPayment] = useRecoilState<string>(paymentOrder);
-  const [bank, setBank] = useRecoilState(bankName);
-  const [number, setNumber] = useRecoilState(accountNumber);
-  const [codeAndId, setCodeAndId] = useRecoilState(lessonCodeAndPaymentId);
+  const setAmount = useSetRecoilState<number>(moneyAmount);
+  const setCount = useSetRecoilState<number>(cycleNumberState);
+  const setPayment = useSetRecoilState<string>(paymentOrder);
+  const setBank = useSetRecoilState(bankName);
+  const setNumber = useSetRecoilState(accountNumber);
+  const setCodeAndId = useSetRecoilState(lessonCodeAndPaymentId);
 
   function resetAllStates() {
     setStudentName("");
@@ -39,6 +39,11 @@ export default function LessonRegisterComplete() {
     setRegularScheduleList([]);
     setBank("");
     setNumber("");
+  }
+
+  function onHandleNavigate(path: string) {
+    navigate(path);
+    resetAllStates();
   }
 
   return (
@@ -62,9 +67,8 @@ export default function LessonRegisterComplete() {
       <ButtonLayout
         buttonText="학부모님과 함께 관리하기"
         passText="건너뛰고 혼자 관리하기"
-        // TODO 학부모님과 함께 관리하기 버튼 클릭 시 학부모님과 함께 관리하기 페이지로 이동
-        onClickButton={() => navigate("/lesson-connect")}
-        onClickJump={() => navigate("/home")}
+        onClickButton={() => onHandleNavigate("/lesson-connect")}
+        onClickJump={() => onHandleNavigate("/home")}
       />
     </ConfirmWrapper>
   );


### PR DESCRIPTION
## 🔥 Related Issues

- close #445

## 💙 작업 내용

- [x] 수업 목록 회차 {count} 재정의

## ✅ PR Point

- 취소인 리스트와 취소가 아닌 리스트를 비교해서 취소 회차는 제외하고 숫자를 세주었습니다.
```jsx
  useEffect(() => {
    const combined = cancelScheduleList
      .concat(scheduleList)
      .sort((a: ScheduleListType, b: ScheduleListType) => b.idx - a.idx);
    setCombinedClasses(combined);
    setOrderedSchedules(processAndOrderSchedules(combined));
  }, [cancelScheduleList, scheduleList]);
```
취소된 수업 목록과 취소가 아닌 (출석, 결석, 상태 없음) 목록을 합친 후 서버에 저장된 idx 값으로 sort 해주고 해당 값을 저장합니다.

저장된 배열을 아래 함수에 넣어서 취소된 회차의 index 값에는 0을, 취소되지 않은 회차의 index 값이 작은 순서부터 오름차순 수를 넣어줍니다.

```jsx
function processAndOrderSchedules(schedules: ScheduleListType[]) {
  const totalNonCanceled = schedules.reduce((acc, schedule) => {
    return acc + (schedule.status !== "취소" ? 1 : 0);
  }, 0);

  let currentOrder = totalNonCanceled;
  return schedules.map((schedule) => {
    if (schedule.status !== "취소") {
      return currentOrder--;
    }
    return 0;
  });
}

```

수업 정보를 전달하는 Props에 orderedSchedules의 index 값을 뿌려주어 올바른 회차 정보가 보이게 합니다
```jsx
          {combinedClasses?.map(({ idx, date, status, startTime, endTime }: ScheduleListType, index: number) => (
            <AttendanceInform
              key={idx}
              date={date}
              status={status}
              startTime={startTime}
              endTime={endTime}
              count={orderedSchedules[index]}
              lessonIdx={idx}
              scheduleIdx={idx}
              setIsCancelImpossibleModalOpen={setIsCancelImpossibleModalOpen}
              isUpdateOpen={isUpdateOpen}
            />
          ))}
```

## 👀 스크린샷 / GIF / 링크

변경 전
<img width="381" alt="image" src="https://github.com/Gwasuwon-shot/Tutice_Client/assets/65286685/12f79221-440c-4466-ab1c-001e4538d1f0">

변경 후
<img width="391" alt="image" src="https://github.com/Gwasuwon-shot/Tutice_Client/assets/65286685/b169055e-fb45-466e-b30a-06a7ea646c38">

